### PR TITLE
add min/max to values, boiler flags, ww-prefix, ha-prefix to mqtt

### DIFF
--- a/src/dallassensor.cpp
+++ b/src/dallassensor.cpp
@@ -391,9 +391,9 @@ void DallasSensor::publish_values(const bool force) {
                     // use '_' as HA doesn't like '-' in the topic name
                     std::string topicname = sensor.to_string();
                     std::replace(topicname.begin(), topicname.end(), '-', '_');
-                    snprintf_P(topic, sizeof(topic), PSTR("homeassistant/sensor/%s/dallas_sensor%s/config"), Mqtt::base().c_str(), topicname.c_str());
+                    snprintf_P(topic, sizeof(topic), PSTR("sensor/%s/dallas_sensor%s/config"), Mqtt::base().c_str(), topicname.c_str());
                 } else {
-                    snprintf_P(topic, sizeof(topic), PSTR("homeassistant/sensor/%s/dallas_sensor%d/config"), Mqtt::base().c_str(), sensor_no);
+                    snprintf_P(topic, sizeof(topic), PSTR("sensor/%s/dallas_sensor%d/config"), Mqtt::base().c_str(), sensor_no);
                 }
                 Mqtt::publish_ha(topic, config.as<JsonObject>());
 

--- a/src/device_library.h
+++ b/src/device_library.h
@@ -27,7 +27,7 @@
 { 64, DeviceType::BOILER, F("BK13/BK15/Smartline/GB1x2"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
 { 72, DeviceType::BOILER, F("GB125/MC10"), DeviceFlags::EMS_DEVICE_FLAG_EMS},
 { 84, DeviceType::BOILER, F("Logamax Plus GB022"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
-{ 95, DeviceType::BOILER, F("Condens 2500/Logamax/Logomatic/Cerapur Top/Greenstar/Generic HT3"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
+{ 95, DeviceType::BOILER, F("Condens 2500/Logamax/Logomatic/Cerapur Top/Greenstar/Generic HT3"), DeviceFlags::EMS_DEVICE_FLAG_HT3},
 {115, DeviceType::BOILER, F("Topline/GB162"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
 {122, DeviceType::BOILER, F("Proline"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
 {123, DeviceType::BOILER, F("GBx72/Trendline/Cerapur/Greenstar Si/27i"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
@@ -35,7 +35,7 @@
 {133, DeviceType::BOILER, F("GB125/Logamatic MC110"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
 {167, DeviceType::BOILER, F("Cerapur Aero"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
 {170, DeviceType::BOILER, F("Logano GB212"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
-{172, DeviceType::BOILER, F("Enviline/Compress 6000AW/Hybrid 7000iAW/SupraEco"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
+{172, DeviceType::BOILER, F("Enviline/Compress 6000AW/Hybrid 7000iAW/SupraEco"), DeviceFlags::EMS_DEVICE_FLAG_HEATPUMP},
 {195, DeviceType::BOILER, F("Condens 5000i/Greenstar 8000"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
 {203, DeviceType::BOILER, F("Logamax U122/Cerapur"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
 {208, DeviceType::BOILER, F("Logamax Plus/GB192/Condens GC9000"), DeviceFlags::EMS_DEVICE_FLAG_NONE},
@@ -80,6 +80,7 @@
 {157, DeviceType::THERMOSTAT, F("RC200/CW100"), DeviceFlags::EMS_DEVICE_FLAG_RC100}, // 0x18
 {158, DeviceType::THERMOSTAT, F("RC300/RC310/Moduline 3000/1010H/CW400/Sense II"), DeviceFlags::EMS_DEVICE_FLAG_RC300}, // 0x10
 {165, DeviceType::THERMOSTAT, F("RC100/Moduline 1000/1010"), DeviceFlags::EMS_DEVICE_FLAG_RC100}, // 0x18, 0x38
+{216, DeviceType::THERMOSTAT, F("CRF200S"), DeviceFlags::EMS_DEVICE_FLAG_RC100}, // 0x18
 
 // Thermostat - Sieger - 0x10 / 0x17
 { 66, DeviceType::THERMOSTAT, F("ES72/RC20"), DeviceFlags::EMS_DEVICE_FLAG_RC20_N}, // 0x17 or remote

--- a/src/devices/boiler.h
+++ b/src/devices/boiler.h
@@ -32,6 +32,11 @@ class Boiler : public EMSdevice {
   private:
     static uuid::log::Logger logger_;
 
+    // specific boiler characteristics, stripping the top 4 bits
+    inline uint8_t model() const {
+        return (flags() & 0x0F);
+    }
+
     void check_active(const bool force = false);
 
     uint8_t boilerState_ = EMS_VALUE_UINT_NOTSET; // Boiler state flag - FOR INTERNAL USE
@@ -84,6 +89,8 @@ class Boiler : public EMSdevice {
 
     // main
     uint8_t  id_;               // product id
+    uint8_t  dummy8u_;          // for commands with no output
+    uint8_t  dummybool_;        // for commands with no output
     uint8_t  heatingActive_;    // Central heating is on/off
     uint8_t  tapwaterActive_;   // Hot tap water is on/off
     uint8_t  selFlowTemp_;      // Selected flow temperature
@@ -141,7 +148,7 @@ class Boiler : public EMSdevice {
     uint32_t nrgSuppCooling_;            // Energy supplied cooling
     uint32_t auxElecHeatNrgConsTotal_;   // Auxiliary electrical heater energy consumption total
     uint32_t auxElecHeatNrgConsHeating_; // Auxiliary electrical heater energy consumption heating
-    uint32_t auxElecHeatNrgConsDHW_;     // Auxiliary electrical heater energy consumption DHW
+    uint32_t auxElecHeatNrgConsWW_;      // Auxiliary electrical heater energy consumption DHW
     char     maintenanceMessage_[4];
     char     maintenanceDate_[12];
     uint8_t  maintenanceType_;

--- a/src/devices/heatpump.cpp
+++ b/src/devices/heatpump.cpp
@@ -33,7 +33,7 @@ Heatpump::Heatpump(uint8_t device_type, uint8_t device_id, uint8_t product_id, c
     register_telegram_type(0x047B, F("HP2"), true, MAKE_PF_CB(process_HPMonitor2));
 
     // device values
-    register_device_value(TAG_NONE, &id_, DeviceValueType::UINT, nullptr, F("id"), nullptr, DeviceValueUOM::NONE); // empty full name to prevent being shown in web or console
+    register_device_value(TAG_NONE, &id_, DeviceValueType::UINT, nullptr, FL_(ID), DeviceValueUOM::NONE);
     register_device_value(TAG_NONE, &airHumidity_, DeviceValueType::UINT, FL_(div2), FL_(airHumidity), DeviceValueUOM::PERCENT);
     register_device_value(TAG_NONE, &dewTemperature_, DeviceValueType::UINT, nullptr, FL_(dewTemperature), DeviceValueUOM::DEGREES);
 
@@ -61,7 +61,7 @@ bool Heatpump::publish_ha_config() {
     ids.add("ems-esp-heatpump");
 
     char topic[Mqtt::MQTT_TOPIC_MAX_SIZE];
-    snprintf_P(topic, sizeof(topic), PSTR("homeassistant/sensor/%s/heatpump/config"), Mqtt::base().c_str());
+    snprintf_P(topic, sizeof(topic), PSTR("sensor/%s/heatpump/config"), Mqtt::base().c_str());
     Mqtt::publish_ha(topic, doc.as<JsonObject>()); // publish the config payload with retain flag
 
     return true;

--- a/src/devices/mixer.cpp
+++ b/src/devices/mixer.cpp
@@ -57,7 +57,7 @@ Mixer::Mixer(uint8_t device_type, uint8_t device_id, uint8_t product_id, const s
         type_       = Type::HC;
         hc_         = device_id - 0x20 + 1;
         uint8_t tag = TAG_HC1 + hc_ - 1;
-        register_device_value(tag, &id_, DeviceValueType::UINT, nullptr, F("id"), nullptr, DeviceValueUOM::NONE); // empty full name to prevent being shown in web or console
+        register_device_value(tag, &id_, DeviceValueType::UINT, nullptr, FL_(ID), DeviceValueUOM::NONE);
         register_device_value(tag, &flowSetTemp_, DeviceValueType::UINT, nullptr, FL_(flowSetTemp), DeviceValueUOM::DEGREES);
         register_device_value(tag, &flowTempHc_, DeviceValueType::USHORT, FL_(div10), FL_(flowTempHc), DeviceValueUOM::DEGREES);
         register_device_value(tag, &pumpStatus_, DeviceValueType::BOOL, nullptr, FL_(pumpStatus), DeviceValueUOM::PUMP);
@@ -67,7 +67,7 @@ Mixer::Mixer(uint8_t device_type, uint8_t device_id, uint8_t product_id, const s
         type_       = Type::WWC;
         hc_         = device_id - 0x28 + 1;
         uint8_t tag = TAG_WWC1 + hc_ - 1;
-        register_device_value(tag, &id_, DeviceValueType::UINT, nullptr, F("id"), nullptr, DeviceValueUOM::NONE); // empty full name to prevent being shown in web or console
+        register_device_value(tag, &id_, DeviceValueType::UINT, nullptr, FL_(ID), DeviceValueUOM::NONE);
         register_device_value(tag, &flowTempHc_, DeviceValueType::USHORT, FL_(div10), FL_(wwTemp), DeviceValueUOM::DEGREES);
         register_device_value(tag, &pumpStatus_, DeviceValueType::BOOL, nullptr, FL_(pumpStatus), DeviceValueUOM::PUMP);
         register_device_value(tag, &status_, DeviceValueType::INT, nullptr, FL_(tempStatus), DeviceValueUOM::NONE);
@@ -109,9 +109,9 @@ bool Mixer::publish_ha_config() {
     // determine the topic, if its HC and WWC. This is determined by the incoming telegram types.
     std::string topic(Mqtt::MQTT_TOPIC_MAX_SIZE, '\0');
     if (type_ == Type::HC) {
-        snprintf_P(&topic[0], topic.capacity() + 1, PSTR("homeassistant/sensor/%s/mixer_hc%d/config"), Mqtt::base().c_str(), hc_);
+        snprintf_P(&topic[0], topic.capacity() + 1, PSTR("sensor/%s/mixer_hc%d/config"), Mqtt::base().c_str(), hc_);
     } else {
-        snprintf_P(&topic[0], topic.capacity() + 1, PSTR("homeassistant/sensor/%s/mixer_wwc%d/config"), Mqtt::base().c_str(), hc_); // WWC
+        snprintf_P(&topic[0], topic.capacity() + 1, PSTR("sensor/%s/mixer_wwc%d/config"), Mqtt::base().c_str(), hc_); // WWC
     }
 
     Mqtt::publish_ha(topic, doc.as<JsonObject>()); // publish the config payload with retain flag

--- a/src/devices/solar.h
+++ b/src/devices/solar.h
@@ -75,6 +75,14 @@ class Solar : public EMSdevice {
     uint8_t  climateZone_;    // climate zone identifier
     uint16_t collector1Area_; // Area of collector field 1
     uint8_t  collector1Type_; // Type of collector field 1, 01=flat, 02=vacuum
+  // SM100wwTemperature - 0x07D6
+    uint8_t wwTemp_1_;
+    uint8_t wwTemp_3_;
+    uint8_t wwTemp_4_;
+    uint8_t wwTemp_5_;
+    uint8_t wwTemp_7_;
+    // SM100wwStatus - 0x07AA
+    uint8_t wwPump_;
 
     char    type_[20]; // Solar of WWC
     uint8_t id_;

--- a/src/devices/switch.cpp
+++ b/src/devices/switch.cpp
@@ -34,7 +34,7 @@ Switch::Switch(uint8_t device_type, uint8_t device_id, uint8_t product_id, const
     register_telegram_type(0x9D, F("WM10SetMessage"), false, MAKE_PF_CB(process_WM10SetMessage));
     register_telegram_type(0x1E, F("WM10TempMessage"), false, MAKE_PF_CB(process_WM10TempMessage));
 
-    register_device_value(TAG_NONE, &id_, DeviceValueType::UINT, nullptr, F("id"), nullptr, DeviceValueUOM::NONE); // empty full name to prevent being shown in web or console
+    register_device_value(TAG_NONE, &id_, DeviceValueType::UINT, nullptr, FL_(ID), DeviceValueUOM::NONE);
     register_device_value(TAG_NONE, &activated_, DeviceValueType::BOOL, nullptr, FL_(activated), DeviceValueUOM::NONE);
     register_device_value(TAG_NONE, &flowTempHc_, DeviceValueType::USHORT, FL_(div10), FL_(flowTempHc), DeviceValueUOM::DEGREES);
     register_device_value(TAG_NONE, &status_, DeviceValueType::INT, nullptr, FL_(status), DeviceValueUOM::NONE);
@@ -66,7 +66,7 @@ bool Switch::publish_ha_config() {
     ids.add("ems-esp-switch");
 
     char topic[Mqtt::MQTT_TOPIC_MAX_SIZE];
-    snprintf_P(topic, sizeof(topic), PSTR("homeassistant/sensor/%s/switch/config"), Mqtt::base().c_str());
+    snprintf_P(topic, sizeof(topic), PSTR("sensor/%s/switch/config"), Mqtt::base().c_str());
     Mqtt::publish_ha(topic, doc.as<JsonObject>()); // publish the config payload with retain flag
 
     return true;

--- a/src/devices/thermostat.h
+++ b/src/devices/thermostat.h
@@ -37,7 +37,7 @@ class Thermostat : public EMSdevice {
         int16_t setpoint_roomTemp;
         int16_t curr_roomTemp;
         int16_t remotetemp; // for readback
-         uint8_t tempautotemp;
+        uint8_t tempautotemp;
         uint8_t mode;
         uint8_t modetype;
         uint8_t summermode;
@@ -143,7 +143,8 @@ class Thermostat : public EMSdevice {
     char     dateTime_[25];  // date and time stamp
     char     errorCode_[15]; // code from 0xA2 as string i.e. "A22(816)"
     uint16_t errorNumber_;   // used internally to build error code
-    char     lastCode_[30];
+    char     lastCode_[30];  // error log
+    char     dummychar_[5];  // for commands with no output
 
     // Installation parameters
     uint8_t ibaMainDisplay_;       // display on Thermostat: 0 int temp, 1 int setpoint, 2 ext temp, 3 burner temp, 4 ww temp, 5 functioning mode, 6 time, 7 data, 9 smoke temp

--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -44,7 +44,7 @@ static const __FlashStringHelper * const DeviceValueTAG_s[] PROGMEM = {
     F_(tag_none),            // ""
     F_(tag_heartbeat),       // ""
     F_(tag_boiler_data),     // ""
-    F_(tag_boiler_data_ww),  // "warm water"
+    F_(tag_device_data_ww),  // "warm water"
     F_(tag_thermostat_data), // ""
     F_(tag_hc1),             // "hc1"
     F_(tag_hc2),             // "hc2"
@@ -77,9 +77,9 @@ static const __FlashStringHelper * const DeviceValueTAG_s[] PROGMEM = {
 static const __FlashStringHelper * const DeviceValueTAG_mqtt[] PROGMEM = {
 
     F_(tag_none),                // ""
-    F_(tag_heartbeat_mqtt),      // "heartbeat"
+    F_(heartbeat),               // "heartbeat"
     F_(tag_boiler_data_mqtt),    // ""
-    F_(tag_boiler_data_ww_mqtt), // "ww"
+    F_(tag_device_data_ww_mqtt), // "ww"
     F_(tag_thermostat_data),     // ""
     F_(tag_hc1),                 // "hc1"
     F_(tag_hc2),                 // "hc2"
@@ -412,9 +412,9 @@ void EMSdevice::register_mqtt_topic(const std::string & topic, mqtt_subfunction_
 }
 
 // add command to library
-void EMSdevice::register_cmd(const __FlashStringHelper * cmd, cmdfunction_p f, uint8_t flag) {
-    Command::add(device_type_, cmd, f, flag);
-}
+// void EMSdevice::register_cmd(const __FlashStringHelper * cmd, cmdfunction_p f, uint8_t flag) {
+//     Command::add(device_type_, cmd, f, flag);
+// }
 
 // register a callback function for a specific telegram type
 void EMSdevice::register_telegram_type(const uint16_t telegram_type_id, const __FlashStringHelper * telegram_type_name, bool fetch, process_function_p f) {
@@ -437,7 +437,9 @@ void EMSdevice::register_device_value(uint8_t                             tag,
                                       const __FlashStringHelper *         short_name,
                                       const __FlashStringHelper *         full_name,
                                       uint8_t                             uom,
-                                      bool                                has_cmd) {
+                                      bool                                has_cmd,
+                                      int32_t                             min,
+                                      uint32_t                            max) {
     // init the value depending on it's type
     if (type == DeviceValueType::TEXT) {
         *(char *)(value_p) = {'\0'};
@@ -449,8 +451,10 @@ void EMSdevice::register_device_value(uint8_t                             tag,
         *(uint16_t *)(value_p) = EMS_VALUE_USHORT_NOTSET;
     } else if ((type == DeviceValueType::ULONG) || (type == DeviceValueType::TIME)) {
         *(uint32_t *)(value_p) = EMS_VALUE_ULONG_NOTSET;
+    } else if (type == DeviceValueType::BOOL) {
+        *(int8_t *)(value_p) = EMS_VALUE_BOOL_NOTSET; // bool is uint8_t, but other initial value
     } else {
-        *(uint8_t *)(value_p) = EMS_VALUE_UINT_NOTSET; // enums, uint8_t, bool behave as uint8_t
+        *(uint8_t *)(value_p) = EMS_VALUE_UINT_NOTSET; // enums behave as uint8_t
     }
 
     // count #options
@@ -462,11 +466,11 @@ void EMSdevice::register_device_value(uint8_t                             tag,
         };
     }
 
-    devicevalues_.emplace_back(device_type_, tag, value_p, type, options, options_size, short_name, full_name, uom, 0, has_cmd);
+    devicevalues_.emplace_back(device_type_, tag, value_p, type, options, options_size, short_name, full_name, uom, 0, has_cmd, min, max);
 }
 
-void EMSdevice::register_device_value(uint8_t tag, void * value_p, uint8_t type, const __FlashStringHelper * const * options, const __FlashStringHelper * const * name, uint8_t uom, cmdfunction_p f) {
-    register_device_value(tag, value_p, type, options, name[0], name[1], uom, (f != nullptr));
+void EMSdevice::register_device_value(uint8_t tag, void * value_p, uint8_t type, const __FlashStringHelper * const * options, const __FlashStringHelper * const * name, uint8_t uom, cmdfunction_p f, int32_t min, uint32_t max) {
+    register_device_value(tag, value_p, type, options, name[0], name[1], uom, (f != nullptr), min, max);
     if (f != nullptr) {
         if (tag >= TAG_HC1 && tag <= TAG_HC4) {
             Command::add(device_type_, name[0], f, FLAG_HC);
@@ -476,11 +480,23 @@ void EMSdevice::register_device_value(uint8_t tag, void * value_p, uint8_t type,
     }
 }
 
+void EMSdevice::register_device_value(uint8_t tag, void * value_p, uint8_t type, const __FlashStringHelper * const * options, const __FlashStringHelper * const * name, uint8_t uom, cmdfunction_p f) {
+    register_device_value(tag, value_p, type, options, name, uom, f, 0, 0);
+}
+
+// void EMSdevice::register_device_value(uint8_t tag, void * value_p, uint8_t type, const __FlashStringHelper * const * options, const __FlashStringHelper * const * name, uint8_t uom, int32_t min, uint32_t max) {
+//     register_device_value(tag, value_p, type, options, name, uom, nullptr, min, max);
+// }
+
+void EMSdevice::register_device_value(uint8_t tag, void * value_p, uint8_t type, const __FlashStringHelper * const * options, const __FlashStringHelper * const * name, uint8_t uom) {
+    register_device_value(tag, value_p, type, options, name, uom, nullptr, 0, 0);
+}
+
 // looks up the uom (suffix) for a given key from the device value table
 std::string EMSdevice::get_value_uom(const char * key) {
     // the key may have a suffix at the start which is between brackets. remove it.
     char new_key[80];
-    strncpy(new_key, key, sizeof(new_key));
+    strlcpy(new_key, key, sizeof(new_key));
     char * p = new_key;
     if (key[0] == '(') {
         while ((*p++ != ')') && (*p != '\0'))
@@ -732,7 +748,11 @@ bool EMSdevice::get_value_info(JsonObject & root, const char * cmd, const int8_t
                 json["unit"] = EMSdevice::uom_to_string(dv.uom);
             }
             json["writeable"] = dv.has_cmd;
-            return true;
+            if (dv.min != 0 || dv.max != 0) {
+                json["min"]   = dv.min;
+                json["max"]   = dv.max;
+            }
+             return true;
         }
     }
     return false;
@@ -879,7 +899,7 @@ bool EMSdevice::generate_values_json(JsonObject & root, const uint8_t tag_filter
                 }
             }
         }
-        dv.ha |= has_value ? DeviceValueHA::HA_VALUE : DeviceValueHA::HA_NONE;
+        dv.ha      |= has_value ? DeviceValueHA::HA_VALUE : DeviceValueHA::HA_NONE;
         has_values |= has_value;
     }
 

--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -720,12 +720,29 @@ bool EMSdevice::get_value_info(JsonObject & root, const char * cmd, const int8_t
                 json["min"]   = 0;
                 json["max"]   = divider ? EMS_VALUE_ULONG_NOTSET / divider : EMS_VALUE_ULONG_NOTSET;
                 break;
-            case DeviceValueType::BOOL:
+            case DeviceValueType::BOOL: {
                 if (Helpers::hasValue(*(uint8_t *)(dv.value_p), EMS_VALUE_BOOL)) {
                     json["value"] = (bool)(*(uint8_t *)(dv.value_p)) ? true : false;
                 }
                 json["type"]  = F("boolean");
+                json["min"]   = 0;
+                json["max"]   = 1;
+                JsonArray enum_ = json.createNestedArray(F("enum"));
+                if (dv.options_size == 2) {
+                    enum_.add(dv.options[1]);
+                    enum_.add(dv.options[0]);
+                } else if (Mqtt::bool_format() == BOOL_FORMAT_ONOFF) {
+                    enum_.add("off");
+                    enum_.add("on");
+                } else if (Mqtt::bool_format() == BOOL_FORMAT_ONOFF_CAP) {
+                    enum_.add("OFF");
+                    enum_.add("ON");
+                } else {
+                    enum_.add(false);
+                    enum_.add(true);
+                }
                 break;
+            }
             case DeviceValueType::TIME:
                 if (Helpers::hasValue(*(uint32_t *)(dv.value_p))) {
                     json["value"] = (divider) ? *(uint32_t *)(dv.value_p) / divider : *(uint32_t *)(dv.value_p);

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -450,8 +450,8 @@ void EMSESP::publish_device_values(uint8_t device_type) {
                 emsdevice->generate_values_json(json, DeviceValueTAG::TAG_BOILER_DATA, false);
                 Mqtt::publish(Mqtt::tag_to_topic(device_type, DeviceValueTAG::TAG_BOILER_DATA), json);
                 json.clear();
-                emsdevice->generate_values_json(json, DeviceValueTAG::TAG_BOILER_DATA_WW, false);
-                Mqtt::publish(Mqtt::tag_to_topic(device_type, DeviceValueTAG::TAG_BOILER_DATA_WW), json);
+                emsdevice->generate_values_json(json, DeviceValueTAG::TAG_DEVICE_DATA_WW, false);
+                Mqtt::publish(Mqtt::tag_to_topic(device_type, DeviceValueTAG::TAG_DEVICE_DATA_WW), json);
                 need_publish = false;
             }
 
@@ -544,7 +544,7 @@ void EMSESP::publish_response(std::shared_ptr<const Telegram> telegram) {
         doc["value"] = value;
     }
 
-    Mqtt::publish(F("response"), doc.as<JsonObject>());
+    Mqtt::publish(F_(response), doc.as<JsonObject>());
 }
 
 bool EMSESP::get_device_value_info(JsonObject & root, const char * cmd, const int8_t id, const uint8_t devicetype) {

--- a/src/locale_EN.h
+++ b/src/locale_EN.h
@@ -149,6 +149,54 @@ MAKE_PSTR_LIST(div10, F_(10))
 MAKE_PSTR_LIST(div100, F_(100))
 MAKE_PSTR_LIST(div60, F_(60))
 
+// Unit Of Measurement mapping - maps to DeviceValueUOM_s in emsdevice.cpp
+// uom - also used with HA
+MAKE_PSTR(percent, "%")
+MAKE_PSTR(degrees, "°C")
+MAKE_PSTR(kwh, "kWh")
+MAKE_PSTR(wh, "Wh")
+MAKE_PSTR(bar, "bar")
+MAKE_PSTR(minutes, "minutes")
+MAKE_PSTR(hours, "hours")
+MAKE_PSTR(ua, "uA")
+MAKE_PSTR(lmin, "l/min")
+
+// TAG mapping - maps to DeviceValueTAG_s in emsdevice.cpp
+// use empty string if want to suppress showing tags
+MAKE_PSTR(tag_none, "")
+MAKE_PSTR(tag_heartbeat, "")
+MAKE_PSTR(tag_boiler_data, "")
+MAKE_PSTR(tag_device_data_ww, "warm water")
+MAKE_PSTR(tag_thermostat_data, "")
+MAKE_PSTR(tag_hc1, "hc1")
+MAKE_PSTR(tag_hc2, "hc2")
+MAKE_PSTR(tag_hc3, "hc3")
+MAKE_PSTR(tag_hc4, "hc4")
+MAKE_PSTR(tag_wwc1, "wwc1")
+MAKE_PSTR(tag_wwc2, "wwc2")
+MAKE_PSTR(tag_wwc3, "wwc3")
+MAKE_PSTR(tag_wwc4, "wwc4")
+MAKE_PSTR(tag_hs1, "hs1")
+MAKE_PSTR(tag_hs2, "hs2")
+MAKE_PSTR(tag_hs3, "hs3")
+MAKE_PSTR(tag_hs4, "hs4")
+MAKE_PSTR(tag_hs5, "hs5")
+MAKE_PSTR(tag_hs6, "hs6")
+MAKE_PSTR(tag_hs7, "hs7")
+MAKE_PSTR(tag_hs8, "hs8")
+MAKE_PSTR(tag_hs9, "hs9")
+MAKE_PSTR(tag_hs10, "hs10")
+MAKE_PSTR(tag_hs11, "hs11")
+MAKE_PSTR(tag_hs12, "hs12")
+MAKE_PSTR(tag_hs13, "hs13")
+MAKE_PSTR(tag_hs14, "hs14")
+MAKE_PSTR(tag_hs15, "hs15")
+MAKE_PSTR(tag_hs16, "hs16")
+
+// MQTT topic names
+// MAKE_PSTR(tag_heartbeat_mqtt, "heartbeat")
+MAKE_PSTR(tag_boiler_data_mqtt, "")
+MAKE_PSTR(tag_device_data_ww_mqtt, "ww")
 
 // boiler
 MAKE_PSTR_WORD(time)
@@ -169,6 +217,8 @@ MAKE_PSTR_WORD(flow)
 MAKE_PSTR_WORD(buffer)
 MAKE_PSTR(bufferedflow, "buffered flow")
 MAKE_PSTR(layeredbuffer, "layered buffer")
+MAKE_PSTR_WORD(maintenance)
+MAKE_PSTR_WORD(error)
 
 // boiler lists
 MAKE_PSTR_LIST(enum_off_time_date, F_(off), F_(time), F_(date))
@@ -176,6 +226,7 @@ MAKE_PSTR_LIST(enum_freq, F_(off), F_(1x3min), F_(2x3min), F_(3x3min), F_(4x3min
 MAKE_PSTR_LIST(enum_charge, F_(3wayvalve), F_(chargepump))
 MAKE_PSTR_LIST(enum_comfort, F_(hot), F_(eco), F_(intelligent))
 MAKE_PSTR_LIST(enum_flow, F_(off), F_(flow), F_(bufferedflow), F_(buffer), F_(layeredbuffer))
+MAKE_PSTR_LIST(enum_reset, F_(maintenance), F_(error))
 
 // thermostat
 MAKE_PSTR_WORD(light)
@@ -205,6 +256,7 @@ MAKE_PSTR_WORD(room)
 MAKE_PSTR_WORD(power)
 MAKE_PSTR_WORD(constant)
 MAKE_PSTR_WORD(simple)
+MAKE_PSTR_WORD(optimized)
 MAKE_PSTR_WORD(nofrost)
 MAKE_PSTR_WORD(comfort)
 MAKE_PSTR_WORD(manual)
@@ -221,7 +273,6 @@ MAKE_PSTR_WORD(maxflow)
 
 MAKE_PSTR_WORD(rc3x)
 MAKE_PSTR_WORD(rc20)
-MAKE_PSTR_WORD(error)
 MAKE_PSTR(internal_temperature, "internal temperature")
 MAKE_PSTR(internal_setpoint, "internal setpoint")
 MAKE_PSTR(external_temperature, "external temperature")
@@ -255,8 +306,9 @@ MAKE_PSTR_LIST(enum_modetype4, F_(blank), F_(nofrost), F_(eco), F_(heat))
 
 MAKE_PSTR_LIST(enum_reducemode, F_(nofrost), F_(reduce), F_(room), F_(outdoor))
 
-MAKE_PSTR_LIST(enum_controlmode, F_(off), F_(outdoor), F_(simple), F_(mpc), F_(room), F_(power), F_(constant))
+MAKE_PSTR_LIST(enum_controlmode, F_(off), F_(optimized), F_(simple), F_(mpc), F_(room), F_(power), F_(constant))
 MAKE_PSTR_LIST(enum_controlmode2, F_(outdoor), F_(room))
+MAKE_PSTR_LIST(enum_controlmode3, F_(off), F_(room), F_(outdoor), F("room+outdoor"))
 MAKE_PSTR_LIST(enum_control, F_(off), F_(rc20), F_(rc3x))
 
 MAKE_PSTR_LIST(enum_hamode, F_(off), F_(heat), F_(auto), F_(heat), F_(off), F_(heat), F_(auto), F_(auto), F_(auto), F_(auto))
@@ -264,15 +316,21 @@ MAKE_PSTR_LIST(enum_hamode, F_(off), F_(heat), F_(auto), F_(heat), F_(off), F_(h
 /*
  * MQTT topics and full text for values and commands
  */
+MAKE_PSTR(homeassistant, "homeassistant/")
+
+// if for all devices
+// empty full name to prevent being shown in web or console
+MAKE_PSTR_LIST(ID, F_(id))
 
 // Boiler
-// extra commands
+// extra commands, no output
 MAKE_PSTR_LIST(wwtapactivated, F("wwtapactivated"))
 MAKE_PSTR_LIST(reset, F("reset"))
 
 // single mqtt topics
-MAKE_PSTR(heating_active, "heating_active")
-MAKE_PSTR(tapwater_active, "tapwater_active")
+MAKE_PSTR_WORD(heating_active)
+MAKE_PSTR_WORD(tapwater_active)
+MAKE_PSTR_WORD(response)
 
 // mqtt, commands and text
 MAKE_PSTR_LIST(heatingActive, F("heatingactive"), F("heating active"))
@@ -313,6 +371,10 @@ MAKE_PSTR_LIST(UBAuptime, F("ubauptime"), F("total UBA operating time"))
 MAKE_PSTR_LIST(lastCode, F("lastcode"), F("last error code"))
 MAKE_PSTR_LIST(serviceCode, F("servicecode"), F("service code"))
 MAKE_PSTR_LIST(serviceCodeNumber, F("servicecodenumber"), F("service code number"))
+MAKE_PSTR_LIST(maintenanceMessage, F("maintenancemessage"), F("maintenance message"))
+MAKE_PSTR_LIST(maintenanceDate, F("maintenancedate"), F("maintenance set date"))
+MAKE_PSTR_LIST(maintenanceType, F_(maintenance), F("maintenance scheduled"))
+MAKE_PSTR_LIST(maintenanceTime, F("maintenancetime"), F("maintenance set time"))
 
 MAKE_PSTR_LIST(upTimeControl, F("uptimecontrol"), F("operating time total heat"))
 MAKE_PSTR_LIST(upTimeCompHeating, F("uptimecompheating"), F("operating time compressor heating"))
@@ -331,11 +393,7 @@ MAKE_PSTR_LIST(nrgSuppWw, F("nrgsuppww"), F("total energy warm supplied warm wat
 MAKE_PSTR_LIST(nrgSuppCooling, F("nrgsuppcooling"), F("total energy supplied cooling"))
 MAKE_PSTR_LIST(auxElecHeatNrgConsTotal, F("auxelecheatnrgconstotal"), F("auxiliary electrical heater energy consumption total"))
 MAKE_PSTR_LIST(auxElecHeatNrgConsHeating, F("auxelecheatnrgconsheating"), F("auxiliary electrical heater energy consumption heating"))
-MAKE_PSTR_LIST(auxElecHeatNrgConsDHW, F("auxelecheatnrgconsww"), F("auxiliary electrical heater energy consumption DHW"))
-MAKE_PSTR_LIST(maintenanceMessage, F("maintenancemessage"), F("maintenance message"))
-MAKE_PSTR_LIST(maintenanceDate, F("maintenancedate"), F("maintenance set date"))
-MAKE_PSTR_LIST(maintenance, F("maintenance"), F("maintenance scheduled"))
-MAKE_PSTR_LIST(maintenanceTime, F("maintenancetime"), F("maintenance set time"))
+MAKE_PSTR_LIST(auxElecHeatNrgConsWW, F("auxelecheatnrgconsww"), F("auxiliary electrical heater energy consumption"))
 
 MAKE_PSTR_LIST(wWSelTemp, F("wwseltemp"), F("selected temperature"))
 MAKE_PSTR_LIST(wWSetTemp, F("wwsettemp"), F("set temperature"))
@@ -370,9 +428,10 @@ MAKE_PSTR_LIST(wWWorkM, F("wwworkm"), F("active time"))
 
 // thermostat
 // extra commands, not published yet
-MAKE_PSTR_LIST(remoteTemp, F("remotetemp"), F("remotetemp"))
 MAKE_PSTR_LIST(switchtime, F("switchtime"), F("switchtime"))
 MAKE_PSTR_LIST(temp, F("temp"), F("temporary set temperature"))
+MAKE_PSTR_LIST(hatemp, F("hatemp"), F("homeassistant temperature"))
+MAKE_PSTR_LIST(hamode, F("hamode"), F("homeassistent mode"))
 
 // mqtt values / commands
 MAKE_PSTR_LIST(dateTime, F("datetime"), F("date/time"))
@@ -392,11 +451,12 @@ MAKE_PSTR_LIST(dampedoutdoortemp, F("dampedoutdoortemp"), F("damped outdoor temp
 MAKE_PSTR_LIST(floordrystatus, F("floordry"), F("floor drying"))
 MAKE_PSTR_LIST(dampedoutdoortemp2, F("dampedoutdoortemp"), F("damped outdoor temperature"))
 MAKE_PSTR_LIST(floordrytemp, F("floordrytemp"), F("floor drying temperature"))
-MAKE_PSTR_LIST(wwMode, F("wwmode"), F("warm water mode"))
-MAKE_PSTR_LIST(wwSetTemp, F("wwsettemp"), F("warm water set temperature"))
-MAKE_PSTR_LIST(wwSetTempLow, F("wwsettemplow"), F("warm water set temperature low"))
-MAKE_PSTR_LIST(wwExtra1, F("wwextra1"), F("warm water circuit 1 extra"))
-MAKE_PSTR_LIST(wwExtra2, F("wwextra2"), F("warm water circuit 2 extra"))
+
+MAKE_PSTR_LIST(wwMode, F("wwmode"), F("mode"))
+MAKE_PSTR_LIST(wwSetTemp, F("wwsettemp"), F("set temperature"))
+MAKE_PSTR_LIST(wwSetTempLow, F("wwsettemplow"), F("set temperature low"))
+MAKE_PSTR_LIST(wwExtra1, F("wwextra1"), F("circuit 1 extra"))
+MAKE_PSTR_LIST(wwExtra2, F("wwextra2"), F("circuit 2 extra"))
 
 MAKE_PSTR_LIST(setpoint_roomTemp, F("seltemp"), F("selected room temperature"))
 MAKE_PSTR_LIST(curr_roomTemp, F("currtemp"), F("current room temperature"))
@@ -450,6 +510,7 @@ MAKE_PSTR_LIST(tempStatus, F("tempstatus"), F("temperature switch in assigned hc
 MAKE_PSTR_LIST(wwTemp, F("wwtemp"), F("current warm water temperature"))
 
 // solar
+MAKE_PSTR_LIST(type, F("type"), F("type"))
 MAKE_PSTR_LIST(collectorTemp, F("collectortemp"), F("collector temperature (TS1)"))
 MAKE_PSTR_LIST(tankBottomTemp, F("tankbottomtemp"), F("tank bottom temperature (TS2)"))
 MAKE_PSTR_LIST(tank2BottomTemp, F("tank2bottomtemp"), F("second tank bottom temperature (TS5)"))
@@ -469,6 +530,13 @@ MAKE_PSTR_LIST(pumpWorkTime, F("pumpWorktime"), F("pump working time"))
 MAKE_PSTR_LIST(energyLastHour, F("energylasthour"), F("energy last hour"))
 MAKE_PSTR_LIST(energyTotal, F("energytotal"), F("energy total"))
 MAKE_PSTR_LIST(energyToday, F("energytoday"), F("energy today"))
+
+MAKE_PSTR_LIST(wwTemp1, F("wwtemp1"), F("temperature 1"))
+MAKE_PSTR_LIST(wwTemp3, F("wwtemp3"), F("temperature 3"))
+MAKE_PSTR_LIST(wwTemp4, F("wwtemp4"), F("temperature 4"))
+MAKE_PSTR_LIST(wwTemp5, F("wwtemp5"), F("temperature 5"))
+MAKE_PSTR_LIST(wwTemp7, F("wwtemp7"), F("temperature 7"))
+MAKE_PSTR_LIST(wwPump, F("wwpump"), F("pump"))
 
 // switch
 MAKE_PSTR_LIST(activated, F("activated"), F("activated"))

--- a/src/locale_EN.h
+++ b/src/locale_EN.h
@@ -427,11 +427,11 @@ MAKE_PSTR_LIST(wWStarts2, F("wwstarts2"), F("# control starts"))
 MAKE_PSTR_LIST(wWWorkM, F("wwworkm"), F("active time"))
 
 // thermostat
-// extra commands, not published yet
-MAKE_PSTR_LIST(switchtime, F("switchtime"), F("switchtime"))
-MAKE_PSTR_LIST(temp, F("temp"), F("temporary set temperature"))
-MAKE_PSTR_LIST(hatemp, F("hatemp"), F("homeassistant temperature"))
-MAKE_PSTR_LIST(hamode, F("hamode"), F("homeassistent mode"))
+// extra commands, no long name, does not show on web
+MAKE_PSTR_LIST(switchtime, F("switchtime"))
+MAKE_PSTR_LIST(temp, F("temp"))
+MAKE_PSTR_LIST(hatemp, F("hatemp"))
+MAKE_PSTR_LIST(hamode, F("hamode"))
 
 // mqtt values / commands
 MAKE_PSTR_LIST(dateTime, F("datetime"), F("date/time"))

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -313,7 +313,7 @@ void Mqtt::on_message(const char * fulltopic, const char * payload, size_t len) 
             if (mf.mqtt_subfunction_) {
                 if (!(mf.mqtt_subfunction_)(message)) {
                     LOG_ERROR(F("MQTT error: invalid payload %s for this topic %s"), message, topic);
-                    Mqtt::publish(F("response"), "invalid");
+                    Mqtt::publish(F_(response), "invalid");
                 }
                 return;
             }
@@ -336,7 +336,7 @@ void Mqtt::on_message(const char * fulltopic, const char * payload, size_t len) 
                 // LOG_INFO(F("devicetype= %d, topic = %s, cmd = %s, message =  %s, id = %d"), mf.device_type_, topic, cmd_only, message, id);
                 if (!Command::call(mf.device_type_, cmd_only, message, id)) {
                     LOG_ERROR(F("No matching cmd (%s) in topic %s, id %d, or invalid data"), cmd_only, topic, id);
-                    Mqtt::publish(F("response"), "unknown");
+                    Mqtt::publish(F_(response), "unknown");
                 }
                 return;
             }
@@ -380,14 +380,14 @@ void Mqtt::on_message(const char * fulltopic, const char * payload, size_t len) 
                 JsonObject          json = resp.to<JsonObject>();
                 cmd_known                = Command::call(mf.device_type_, command, "", n, json);
                 if (cmd_known && json.size()) {
-                    Mqtt::publish(F("response"), resp.as<JsonObject>());
+                    Mqtt::publish(F_(response), resp.as<JsonObject>());
                     return;
                 }
             }
 
             if (!cmd_known) {
                 LOG_ERROR(F("No matching cmd (%s) or invalid data"), command);
-                Mqtt::publish(F("response"), "unknown");
+                Mqtt::publish(F_(response), "unknown");
             }
 
             return;
@@ -681,7 +681,7 @@ void Mqtt::ha_status() {
     ids.add("ems-esp");
 
     char topic[MQTT_TOPIC_MAX_SIZE];
-    snprintf_P(topic, sizeof(topic), PSTR("homeassistant/sensor/%s/system/config"), mqtt_base_.c_str());
+    snprintf_P(topic, sizeof(topic), PSTR("sensor/%s/system/config"), mqtt_base_.c_str());
     Mqtt::publish_ha(topic, doc.as<JsonObject>()); // publish the config payload with retain flag
 
     // create the sensors
@@ -798,14 +798,15 @@ void Mqtt::publish_ha(const std::string & topic, const JsonObject & payload) {
     payload_text.reserve(measureJson(payload) + 1);
     serializeJson(payload, payload_text); // convert json to string
 
+    std::string fulltopic = uuid::read_flash_string(F_(homeassistant)) + topic;
 #if defined(EMSESP_STANDALONE)
-    LOG_DEBUG(F("Publishing HA topic=%s, payload=%s"), topic.c_str(), payload_text.c_str());
+    LOG_DEBUG(F("Publishing HA topic=%s, payload=%s"), fulltopic.c_str(), payload_text.c_str());
 #elif defined(EMSESP_DEBUG)
-    LOG_DEBUG(F("[debug] Publishing HA topic=%s, payload=%s"), topic.c_str(), payload_text.c_str());
+    LOG_DEBUG(F("[debug] Publishing HA topic=%s, payload=%s"), fulltopic.c_str(), payload_text.c_str());
 #endif
 
     // queue messages if the MQTT connection is not yet established. to ensure we don't miss messages
-    queue_publish_message(topic, payload_text, true); // with retain true
+    queue_publish_message(fulltopic, payload_text, true); // with retain true
 }
 
 // take top from queue and perform the publish or subscribe action
@@ -819,7 +820,7 @@ void Mqtt::process_queue() {
     auto mqtt_message = mqtt_messages_.front();
     auto message      = mqtt_message.content_;
     char topic[MQTT_TOPIC_MAX_SIZE];
-    if ((strncmp(message->topic.c_str(), "homeassistant/", 13) == 0)) {
+    if (message->topic.find(uuid::read_flash_string(F_(homeassistant))) == 0) {
         // leave topic as it is
         strcpy(topic, message->topic.c_str());
     } else {
@@ -914,7 +915,7 @@ void Mqtt::publish_mqtt_ha_sensor(uint8_t                     type, // EMSdevice
 
     // device name
     char device_name[50];
-    strncpy(device_name, EMSdevice::device_type_2_device_name(device_type).c_str(), sizeof(device_name));
+    strlcpy(device_name, EMSdevice::device_type_2_device_name(device_type).c_str(), sizeof(device_name));
 
     // build unique identifier which will be used in the topic
     // and replacing all . with _ as not to break HA
@@ -954,7 +955,7 @@ void Mqtt::publish_mqtt_ha_sensor(uint8_t                     type, // EMSdevice
     // look at the device value type
     if (type == DeviceValueType::BOOL) {
         // binary sensor
-        snprintf_P(topic, sizeof(topic), PSTR("homeassistant/binary_sensor/%s/%s/config"), mqtt_base_.c_str(), uniq.c_str()); // topic
+        snprintf_P(topic, sizeof(topic), PSTR("binary_sensor/%s/%s/config"), mqtt_base_.c_str(), uniq.c_str()); // topic
 
         // how to render boolean. HA only accepts String values
         char result[10];
@@ -962,7 +963,7 @@ void Mqtt::publish_mqtt_ha_sensor(uint8_t                     type, // EMSdevice
         doc[F("payload_off")] = Helpers::render_boolean(result, false);
     } else {
         // normal HA sensor, not a boolean one
-        snprintf_P(topic, sizeof(topic), PSTR("homeassistant/sensor/%s/%s/config"), mqtt_base_.c_str(), uniq.c_str()); // topic
+        snprintf_P(topic, sizeof(topic), PSTR("sensor/%s/%s/config"), mqtt_base_.c_str(), uniq.c_str()); // topic
 
         // unit of measure and map the HA icon
         if (uom != DeviceValueUOM::NONE && uom != DeviceValueUOM::PUMP) {
@@ -996,6 +997,7 @@ void Mqtt::publish_mqtt_ha_sensor(uint8_t                     type, // EMSdevice
         ids.add(ha_device);
     }
 
+    doc.shrinkToFit();
     publish_ha(topic, doc.as<JsonObject>());
 }
 

--- a/src/shower.cpp
+++ b/src/shower.cpp
@@ -123,7 +123,7 @@ void Shower::send_mqtt_stat(bool state, bool force) {
         ids.add("ems-esp");
 
         char topic[Mqtt::MQTT_TOPIC_MAX_SIZE];
-        snprintf_P(topic, sizeof(topic), PSTR("homeassistant/binary_sensor/%s/shower_active/config"), Mqtt::base().c_str());
+        snprintf_P(topic, sizeof(topic), PSTR("binary_sensor/%s/shower_active/config"), Mqtt::base().c_str());
         Mqtt::publish_ha(topic, doc.as<JsonObject>()); // publish the config payload with retain flag
     }
 }


### PR DESCRIPTION
When checking the missing commands i found some things:
- there are a lot of "homeassistent/.." topics, i moved this as prefix to mqtt and add/strip it here
- we have a lot of "warm water" also in other devices like mixer, thermostat, solar, I renamed `BOILER_DATA_WW` to `DEVICE_DATA_WW` and used in in all devices
- I added flags to boiler, but only for a few that i know
- add min/max optional to value registration, it's around 2-3k heap, i think the esp32 can manage it. For now it's only thermostat temp to 5-29°C, but we can add one by one if we know the range. If not set the info gives the range of storagefield.

It's working for me, check if you like it. It's a lot of changes for one commit, but one gives another...