### PR TITLE
Show mode (off / heat) in Home Assistant for Moduline 200

### DIFF
--- a/src/devices/thermostat.cpp
+++ b/src/devices/thermostat.cpp
@@ -493,7 +493,15 @@ uint8_t Thermostat::HeatingCircuit::get_mode() const {
         return HeatingCircuit::Mode::UNKNOWN;
     }
 
-    if (model == EMSdevice::EMS_DEVICE_FLAG_RC20) {
+    if (model == EMSdevice::EMS_DEVICE_FLAG_RC10) {
+        if (mode == 1) {
+            return HeatingCircuit::Mode::OFF;
+        } else if (mode == 2) {
+            return HeatingCircuit::Mode::NIGHT;
+        } else if (mode == 4) {
+            return HeatingCircuit::Mode::ON;
+        }
+    } else if (model == EMSdevice::EMS_DEVICE_FLAG_RC20) {
         if (mode == 0) {
             return HeatingCircuit::Mode::OFF;
         } else if (mode == 1) {
@@ -703,7 +711,8 @@ void Thermostat::process_RC10Monitor(std::shared_ptr<const Telegram> telegram) {
     if (hc == nullptr) {
         return;
     }
-
+    has_update(telegram->read_value(hc->mode, 0));
+    hc->hamode = hc->mode == 4 ? 1 : 0;                            // set special HA mode: off, on, auto
     has_update(telegram->read_value(hc->setpoint_roomTemp, 1, 1)); // is * 2, force as single byte
     has_update(telegram->read_value(hc->curr_roomTemp, 2));        // is * 10
 }


### PR DESCRIPTION
Shows mode in Home Assistant based on manually selected mode on thermostat (day or off)
Unfortunately, it does not allow you to set the mode remotely through RC10Set
(RC10Set shows up in log for temp change but not for mode change) 

Below some tests using read:

**read thermostat b1**

day (temp: 20deg, night temp 19deg, off temp 7deg, 7h)
04 28 00 C2 00 00 00 C2

**set** night (temp: 20deg, night temp 19deg, off temp 7deg, 7h)
02 26 00 C2 01 A3 00 C2

night (temp: 20deg, **set** night temp 15deg, off temp 7deg, 7h)
02 1E 00 C5 01 A3 00 C6

**set** off (temp: 20deg, night temp 19deg, off temp 7deg, 7h)
01 0E 00 C2 00 00 00 C2

**set** on (curr temp: 16deg, set temp 19deg)
04 23 00 BA 00 00 00 BA

**read thermostat b0**

off (temp: 20deg, night temp 19deg, return day 7h)
00 FF 00 26 28 07 01

on (**set** temp: 16deg, night temp 19deg, return day 7h)
00 FF 00 26 20 07 01

night (temp: 16deg, **set** night temp 14deg, return day 7h)
00 FF 00 1C 20 07 01

night (temp: 16deg, night temp 14deg, **set** return day 8h)
00 FF 00 1C 20 08 01