### PR TITLE
fix MQTT non-JSON payloads

### DIFF
--- a/pio_local.ini_example
+++ b/pio_local.ini_example
@@ -8,7 +8,7 @@
 my_build_flags =
 
 ; 5=verbose, 4=debug, 3=info
-debug_flags = DCORE_DEBUG_LEVEL=5
+debug_flags = -DCORE_DEBUG_LEVEL=5
 
 [env:esp32]
 ; if using OTA enter your details below
@@ -19,9 +19,7 @@ upload_flags =
 upload_port = ems-esp.local
 
 ; use this when you don't want to re-build the WebUI
-extra_scripts = 
-  scripts/rename_fw.py
-  scripts/upload_fw.py 
+extra_scripts = scripts/rename_fw.py
 
 ; pio run -e debug
 ; or from Visual Studio Code do PIO -> Project Tasks -> debug -> General -> Upload and Monitor

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -151,7 +151,7 @@ uint8_t Command::process(const char * path, const bool is_admin, const JsonObjec
         char data_str[10];
         return_code = Command::call(device_type, command_p, Helpers::render_value(data_str, (float)data.as<float>(), 2), is_admin, id_n, output);
     } else if (data.isNull()) {
-        return_code = Command::call(device_type, command_p, "", is_admin, id_n, output); // empty
+        return_code = Command::call(device_type, command_p, "", is_admin, id_n, output); // empty, will do a query instead
     } else {
         return message(CommandRet::ERROR, "cannot parse command", output); // can't process
     }
@@ -246,6 +246,7 @@ uint8_t Command::call(const uint8_t device_type, const char * cmd, const char * 
     // check if its a call to and end-point to a device, i.e. has no value
     // except for system commands as this is a special device without any queryable entities (device values)
     // exclude SYSTEM and DALLASSENSOR
+
     if ((device_type >= EMSdevice::DeviceType::BOILER) && (!value || !strlen(value))) {
         if (!cf || !cf->cmdfunction_json_) {
 #if defined(EMSESP_DEBUG)

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -640,6 +640,9 @@ void Test::run_test(uuid::console::Shell & shell, const std::string & cmd) {
         EMSESP::mqtt_.incoming("ems-esp/system/publish");
         EMSESP::mqtt_.incoming("ems-esp/thermostat/seltemp"); // empty payload, sends reponse
 
+        EMSESP::mqtt_.incoming("ems-esp/boiler/wwseltemp", "59");
+        EMSESP::mqtt_.incoming("ems-esp/boiler/wwseltemp");
+
         // MQTT bad tests
         EMSESP::mqtt_.incoming("ems-esp/thermostate/mode", "auto");     // unknown device
         EMSESP::mqtt_.incoming("ems-esp/thermostat/modee", "auto");     // unknown command

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define EMSESP_APP_VERSION "3.3.0b4"
+#define EMSESP_APP_VERSION "3.3.0b5"


### PR DESCRIPTION
string payloads were not converted to JSON {"value":xx}. Bug reported via Discord channel.