### PR TITLE
Mode update for #183

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -43,6 +43,7 @@
 - Unit of Measure 'times' added to MQTT Fails, Rx fails, Rx received, Tx fails, Tx reads & Tx writes
 - Improved API. Restful HTTP API works in the same way as MQTT calls
 - Removed settings for MQTT subscribe format [#173](https://github.com/emsesp/EMS-ESP32/issues/173)
+- Improve moduline 200 functionality [#183](https://github.com/emsesp/EMS-ESP32/issues/183)
 
 ## **BREAKING CHANGES**
 

--- a/src/devices/thermostat.h
+++ b/src/devices/thermostat.h
@@ -276,7 +276,7 @@ class Thermostat : public EMSdevice {
     std::shared_ptr<Thermostat::HeatingCircuit> heating_circuit(std::shared_ptr<const Telegram> telegram);
     std::shared_ptr<Thermostat::HeatingCircuit> heating_circuit(const uint8_t hc_num);
 
-    void publish_ha_config_hc(uint8_t hc_num);
+    void publish_ha_config_hc(std::shared_ptr<Thermostat::HeatingCircuit> hc);
     void register_device_values_hc(std::shared_ptr<Thermostat::HeatingCircuit> hc);
 
     bool thermostat_ha_cmd(const char * message, uint8_t hc_num);

--- a/src/locale_EN.h
+++ b/src/locale_EN.h
@@ -339,7 +339,7 @@ MAKE_PSTR_LIST(enum_mode2, F_(off), F_(manual), F_(auto))            // RC20
 MAKE_PSTR_LIST(enum_mode3, F_(night), F_(day), F_(auto))             // RC35, RC30
 MAKE_PSTR_LIST(enum_mode4, F_(nofrost), F_(eco), F_(heat), F_(auto)) // JUNKERS
 MAKE_PSTR_LIST(enum_mode5, F_(auto), F_(off))                        // CRF
-MAKE_PSTR_LIST(enum_mode6, F_(nofrost), F_(night), F_(day))          // RC10
+MAKE_PSTR_LIST(enum_mode6, F_(off), F_(night), F_(day))              // RC10
 
 MAKE_PSTR_LIST(enum_hamode, F_(off), F_(heat), F_(auto), F_(heat), F_(off), F_(heat), F_(auto), F_(auto), F_(auto), F_(auto))
 


### PR DESCRIPTION
Allow mode "off" to be set from home assistant + remove non available "auto" mode from home assistant

Changed nofrost to off because:
- Other thermostats that use nofrost allow the temprature to be set, the moduline 200 does not (fixed at 7 deg).
- Home assistant does not have a nofrost mode e.g. off is used
- Thermostat manual refers to the button as: "off-function"

![image](https://user-images.githubusercontent.com/9843150/141676861-7d76fd95-3dd5-4adc-b42a-02cde1f752ae.png)
