### PR TITLE
bugfix revert auto mode -> the mode is hardcoded for the thermostat_ha_cmd #183

### DIFF
--- a/src/devices/thermostat.cpp
+++ b/src/devices/thermostat.cpp
@@ -2228,8 +2228,14 @@ bool Thermostat::set_temperature(const float temperature, const uint8_t mode, co
         case HeatingCircuit::Mode::DAY:
             offset = 4;
             break;
+        case HeatingCircuit::Mode::AUTO:
+            if (hc->get_mode() == HeatingCircuit::Mode::NIGHT) {
+                offset = 3;
+            } else {
+                offset = 4;
+            }
+            break;
         }
-
     } else if (model == EMS_DEVICE_FLAG_RC20) {
         offset = EMS_OFFSET_RC20Set_temp;
 


### PR DESCRIPTION
@proddy 

Not sure if this is the best solution, always pass AUTO mode and determine inside the function if the mode is actual set to AUTO?

https://github.com/emsesp/EMS-ESP32/blob/5893487d4aed8264ec1a3fbd3da5c9b52b746fc0/src/devices/thermostat.cpp#L483