### PR TITLE
fix overlapping 0xC2 and overflow of offset

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -6,7 +6,7 @@
 
 ## Fixed
 - lastcode broke MQTT JSON structure [#228]
-- overlapping while reading 0xC2 from Boiler
+- overlapping while reading sequence of EMS1.0 telegrams
 - redundant telegram readings (because of offset overflow)
 
 ## Changed

--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -6,6 +6,8 @@
 
 ## Fixed
 - lastcode broke MQTT JSON structure [#228]
+- overlapping while reading 0xC2 from Boiler
+- redundant telegram readings (because of offset overflow)
 
 ## Changed
 

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -1191,7 +1191,7 @@ void EMSESP::incoming_telegram(uint8_t * data, const uint8_t length) {
                 txservice_.send_poll(); // close the bus
                 txservice_.reset_retry_count();
                 tx_successful = true;
-                // if telegram is longer read next part with offset + 25 for ems+
+                // if telegram is longer read next part with offset +25 for ems+ or +27 for ems1.0
                 if (length == 32) {
                     if (txservice_.read_next_tx(data[3]) == read_id_) {
                         read_next_ = true;

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -613,19 +613,10 @@ uint16_t TxService::read_next_tx(uint8_t offset) {
     if (telegram_last_->offset != offset) {
         return 0;
     }
-<<<<<<< Updated upstream
-
-    uint8_t add_offset;
-    if (telegram_last_->dest == 0x08 && telegram_last_->type_id == 0xC2) {  //fix for overlapping 0xC2 telegrams from Boiler. Are other telegrams also affected?
-        add_offset = 27;
-    } else {
-        add_offset = 25;
-=======
     
     uint8_t add_offset = 25;                //for EMS+ telegram increase offset by 25
     if (telegram_last_->type_id < 0x100) {  //but for EMS1.0 by 27
         add_offset = 27;
->>>>>>> Stashed changes
     }
 
     if (UINT8_MAX - telegram_last_->offset < add_offset) {   //stop if new offset would overflow

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -613,7 +613,19 @@ uint16_t TxService::read_next_tx(uint8_t offset) {
     if (telegram_last_->offset != offset) {
         return 0;
     }
-    add(Telegram::Operation::TX_READ, telegram_last_->dest, telegram_last_->type_id, telegram_last_->offset + 25, message_data, 1, 0, true);
+
+    uint8_t add_offset;
+    if (telegram_last_->dest == 0x08 && telegram_last_->type_id == 0xC2) {  //fix for overlapping 0xC2 telegrams from Boiler. Are other telegrams also affected?
+        add_offset = 27;
+    } else {
+        add_offset = 25;
+    }
+
+    if (UINT8_MAX - telegram_last_->offset < add_offset) {   //stop if new offset would overflow
+        return 0;
+    }
+
+    add(Telegram::Operation::TX_READ, telegram_last_->dest, telegram_last_->type_id, telegram_last_->offset + add_offset, message_data, 1, 0, true);
     return telegram_last_->type_id;
 }
 

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -613,12 +613,19 @@ uint16_t TxService::read_next_tx(uint8_t offset) {
     if (telegram_last_->offset != offset) {
         return 0;
     }
+<<<<<<< Updated upstream
 
     uint8_t add_offset;
     if (telegram_last_->dest == 0x08 && telegram_last_->type_id == 0xC2) {  //fix for overlapping 0xC2 telegrams from Boiler. Are other telegrams also affected?
         add_offset = 27;
     } else {
         add_offset = 25;
+=======
+    
+    uint8_t add_offset = 25;                //for EMS+ telegram increase offset by 25
+    if (telegram_last_->type_id < 0x100) {  //but for EMS1.0 by 27
+        add_offset = 27;
+>>>>>>> Stashed changes
     }
 
     if (UINT8_MAX - telegram_last_->offset < add_offset) {   //stop if new offset would overflow


### PR DESCRIPTION
Don't know why but while reading 0xC2 offset should be increased  by 27 not 25 (is it only valid for Buderus WSW196i heat pump?). Furthermore the patch breaks reading of next telegrams in case of offset overflow. Attached files show how it was and how it is now. Was over 200(!) unnecessary telegrams and first two bytes of each telegram are identical to the last two bytes from previous telegram (except the lines with offset overflow).
[before.txt](https://github.com/emsesp/EMS-ESP32/files/7648926/before.txt)
[after.txt](https://github.com/emsesp/EMS-ESP32/files/7648927/after.txt)
