### PR TITLE
tx read/write counters and devices handlers

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -30,8 +30,8 @@
 - Clean up old HA config's in MQTT before publishing data. This will prevent HA giving the 'dict' warnings [#229](https://github.com/emsesp/EMS-ESP32/issues/229)
 - RC25 temperature setting [#272](https://github.com/emsesp/EMS-ESP32/issues/272)
 - Buderus RC25 - "hc1 mode type" incorrect value [#273](https://github.com/emsesp/EMS-ESP32/issues/273)
-- Missing values for damped outdoor temperature [#282](https://github.com/emsesp/EMS-ESP32/issues/282)
 - Increased number of Mixers and Heating Circuits [#294](https://github.com/emsesp/EMS-ESP32/issues/294)
+- Check receive status before removing a telegram fetch [#268](https://github.com/emsesp/EMS-ESP32/issues/268), [#282](https://github.com/emsesp/EMS-ESP32/issues/282)
 
 ## Changed
 
@@ -42,6 +42,8 @@
 - Show Sensors quality in WebUI
 - Controller not shown in WebUI dashboard
 - renamed "Home Assistant Integration" to "MQTT Discovery" in MQTT Settings [#290](https://github.com/emsesp/EMS-ESP32/issues/290)
+- Show ems tx reads and writes separatly
+- Show ems device handlers separated for received, fetched and pending handlers.
 
 **BREAKING CHANGES:**
 

--- a/interface/src/project/DashboardStatus.tsx
+++ b/interface/src/project/DashboardStatus.tsx
@@ -40,7 +40,7 @@ import { extractErrorMessage, useRest } from '../utils';
 
 export const isConnected = ({ status }: Status) => status !== busConnectionStatus.BUS_STATUS_OFFLINE;
 
-export const busStatusHighlight = ({ status }: Status, theme: Theme) => {
+const busStatusHighlight = ({ status }: Status, theme: Theme) => {
   switch (status) {
     case busConnectionStatus.BUS_STATUS_TX_ERRORS:
       return theme.palette.warning.main;
@@ -53,31 +53,16 @@ export const busStatusHighlight = ({ status }: Status, theme: Theme) => {
   }
 };
 
-export const busStatus = ({ status }: Status) => {
+const busStatus = ({ status }: Status) => {
   switch (status) {
     case busConnectionStatus.BUS_STATUS_CONNECTED:
       return 'Connected';
     case busConnectionStatus.BUS_STATUS_TX_ERRORS:
-      return 'Tx Errors';
+      return 'Tx issues - try a different Tx-Mode';
     case busConnectionStatus.BUS_STATUS_OFFLINE:
       return 'Disconnected';
     default:
       return 'Unknown';
-  }
-};
-
-export const txMode = ({ tx_mode }: Status) => {
-  switch (tx_mode) {
-    case 1:
-      return ', Tx-Mode: EMS';
-    case 2:
-      return ', Tx-Mode: EMS+';
-    case 3:
-      return ', Tx-Mode: HT3';
-    case 4:
-      return ', Tx-Mode: Hardware';
-    default:
-      return ', Tx-Mode: Off';
   }
 };
 
@@ -208,11 +193,11 @@ const DashboardStatus: FC = () => {
             <ListItemText
               primary="Active Devices &amp; Sensors"
               secondary={
-                pluralize(data.num_devices, 'device') +
+                pluralize(data.num_devices, 'EMS Device') +
                 ', ' +
-                pluralize(data.num_sensors, 'temperature sensor') +
+                pluralize(data.num_sensors, 'Temperature Sensor') +
                 ', ' +
-                pluralize(data.num_analogs, 'analog sensor')
+                pluralize(data.num_analogs, 'Analog Sensor')
               }
             />
           </ListItem>
@@ -228,8 +213,9 @@ const DashboardStatus: FC = () => {
                 </TableRow>
               </TableHead>
               <TableBody>
-                {formatRow('Telegrams Received (Rx)', data.rx_received, data.rx_fails, data.rx_quality)}
-                {formatRow('Telegrams Sent (Tx)', data.tx_sent, data.tx_fails, data.tx_quality)}
+                {formatRow('EMS Telegrams Received (Rx)', data.rx_received, data.rx_fails, data.rx_quality)}
+                {formatRow('EMS Reads(Tx)', data.tx_reads, data.tx_read_fails, data.tx_read_quality)}
+                {formatRow('EMS Writes (Tx)', data.tx_writes, data.tx_write_fails, data.tx_write_quality)}
                 {formatRow('Temperature Sensor Reads', data.sensor_reads, data.sensor_fails, data.sensor_quality)}
                 {formatRow('Analog Sensor Reads', data.analog_reads, data.analog_fails, data.analog_quality)}
                 {formatRow('MQTT Publishes', data.mqtt_count, data.mqtt_fails, data.mqtt_quality)}

--- a/interface/src/project/types.ts
+++ b/interface/src/project/types.ts
@@ -42,10 +42,13 @@ export interface Status {
   status: busConnectionStatus;
   tx_mode: number;
   rx_received: number;
-  tx_sent: number;
+  tx_reads: number;
+  tx_writes: number;
   rx_quality: number;
-  tx_quality: number;
-  tx_fails: number;
+  tx_read_quality: number;
+  tx_write_quality: number;
+  tx_read_fails: number;
+  tx_write_fails: number;
   rx_fails: number;
   sensor_fails: number;
   sensor_reads: number;

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -128,7 +128,7 @@ uint8_t Command::process(const char * path, const bool is_admin, const JsonObjec
             id_n = input["hc"];
         } else if (input.containsKey("wwc")) {
             id_n = input["wwc"];
-            id_n += 7; // wwc1 has id 8
+            id_n += 8; // wwc1 has id 9
         } else if (input.containsKey("id")) {
             id_n = input["id"];
         }
@@ -213,7 +213,7 @@ const char * Command::parse_command_string(const char * command, int8_t & id) {
     if (!strncmp(command, "hc", 2) && start_pos == 4) {
         id = command[start_pos - 2] - '0';
     } else if (!strncmp(command, "wwc", 3) && start_pos == 5) {
-        id = command[start_pos - 2] - '0' + 7; // wwc1 has id 8
+        id = command[start_pos - 2] - '0' + 8; // wwc1 has id 9
     } else {
 #if defined(EMSESP_DEBUG)
         LOG_DEBUG(F("[DEBUG] Command parse error, unknown hc/wwc in %s"), command_s);

--- a/src/emsdevice.h
+++ b/src/emsdevice.h
@@ -177,8 +177,10 @@ class EMSdevice {
     const std::string to_string() const;
     const std::string to_string_short() const;
 
+    enum Handlers : uint8_t { ALL, RECEIVED, FETCHED, PENDING };
+
     void   show_telegram_handlers(uuid::console::Shell & shell);
-    char * show_telegram_handlers(char * result);
+    char * show_telegram_handlers(char * result, uint8_t handlers);
     void   show_mqtt_handlers(uuid::console::Shell & shell);
     void   list_device_entries(JsonObject & output);
     void   exclude_entity(uint8_t entity_id);

--- a/src/emsesp.h
+++ b/src/emsesp.h
@@ -149,14 +149,6 @@ class EMSESP {
 
     static void incoming_telegram(uint8_t * data, const uint8_t length);
 
-    static uint16_t sensor_reads() {
-        return dallassensor_.reads() + analogsensor_.reads();
-    }
-
-    static uint16_t sensor_fails() {
-        return dallassensor_.fails() + analogsensor_.fails();
-    }
-
     static bool dallas_enabled() {
         return (dallassensor_.dallas_enabled());
     }

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -668,6 +668,7 @@ std::shared_ptr<const MqttMessage> Mqtt::queue_message(const uint8_t operation, 
     // if the queue is full, make room but removing the last one
     if (mqtt_messages_.size() >= MAX_MQTT_MESSAGES) {
         mqtt_messages_.pop_front();
+        LOG_WARNING(F("Queue overflow, removing one message"));
     }
     mqtt_messages_.emplace_back(mqtt_message_id_++, std::move(message));
 

--- a/src/telegram.h
+++ b/src/telegram.h
@@ -325,47 +325,59 @@ class TxService : public EMSbus {
     uint32_t telegram_read_count() const {
         return telegram_read_count_;
     }
+    uint32_t telegram_write_count() const {
+        return telegram_write_count_;
+    }
 
     void telegram_read_count(uint32_t telegram_read_count) {
         telegram_read_count_ = telegram_read_count;
+    }
+
+    void telegram_write_count(uint32_t telegram_write_count) {
+        telegram_write_count_ = telegram_write_count;
     }
 
     void increment_telegram_read_count() {
         telegram_read_count_++;
     }
 
-    uint32_t telegram_fail_count() const {
-        return telegram_fail_count_;
+    void increment_telegram_write_count() {
+        telegram_write_count_++;
+    }
+
+    uint32_t telegram_read_fail_count() const {
+        return telegram_read_fail_count_;
+    }
+
+    uint32_t telegram_write_fail_count() const {
+        return telegram_write_fail_count_;
     }
 
     void telegram_fail_count(uint32_t telegram_fail_count) {
-        telegram_fail_count_ = telegram_fail_count;
+        telegram_read_fail_count_ = telegram_fail_count;
+        telegram_write_fail_count_ = telegram_fail_count;
     }
 
-    uint8_t quality() const {
-        if (telegram_fail_count_ == 0) {
+    uint8_t read_quality() const {
+        if (telegram_read_fail_count_ == 0) {
             return 100; // all good, 100%
         }
-        if (telegram_fail_count_ >= telegram_read_count_) {
-            return 100;
+        return (100 - (uint8_t)((telegram_read_fail_count_ * 100 / (telegram_read_fail_count_ + telegram_read_count_))));
+    }
+
+    uint8_t write_quality() const {
+        if (telegram_write_fail_count_ == 0) {
+            return 100; // all good, 100%
         }
-        return (100 - (uint8_t)(((float)telegram_fail_count_ / telegram_read_count_ * 100)));
+        return (100 - (uint8_t)((telegram_write_fail_count_ * 100 / (telegram_write_fail_count_ + telegram_write_count_))));
     }
 
-    void increment_telegram_fail_count() {
-        telegram_fail_count_++;
+    void increment_telegram_read_fail_count() {
+        telegram_read_fail_count_++;
     }
 
-    uint32_t telegram_write_count() const {
-        return telegram_write_count_;
-    }
-
-    void telegram_write_count(uint8_t telegram_write_count) {
-        telegram_write_count_ = telegram_write_count;
-    }
-
-    void increment_telegram_write_count() {
-        telegram_write_count_++;
+    void increment_telegram_write_fail_count() {
+        telegram_write_fail_count_++;
     }
 
     struct QueuedTxTelegram {
@@ -398,9 +410,10 @@ class TxService : public EMSbus {
   private:
     std::deque<QueuedTxTelegram> tx_telegrams_; // the Tx queue
 
-    uint32_t telegram_read_count_  = 0; // # Tx successful reads
-    uint32_t telegram_write_count_ = 0; // # Tx successful writes
-    uint32_t telegram_fail_count_  = 0; // # Tx unsuccessful transmits
+    uint32_t telegram_read_count_       = 0; // # Tx successful reads
+    uint32_t telegram_write_count_      = 0; // # Tx successful writes
+    uint32_t telegram_read_fail_count_  = 0; // # Tx unsuccessful transmits
+    uint32_t telegram_write_fail_count_ = 0; // # Tx unsuccessful transmits
 
     std::shared_ptr<Telegram> telegram_last_;
     uint16_t                  telegram_last_post_send_query_; // which type ID to query after a successful send, to read back the values just written

--- a/src/web/WebLogService.cpp
+++ b/src/web/WebLogService.cpp
@@ -193,7 +193,7 @@ void WebLogService::transmit(const QueuedLogMessage & message) {
 
 // send the complete log buffer to the API, not filtering on log level
 void WebLogService::fetchLog(AsyncWebServerRequest * request) {
-    MsgpackAsyncJsonResponse * response = new MsgpackAsyncJsonResponse(false, EMSESP_JSON_SIZE_XXLARGE_DYN); // 16kb buffer
+    MsgpackAsyncJsonResponse * response = new MsgpackAsyncJsonResponse(false, EMSESP_JSON_SIZE_LARGE_DYN + 192 * log_messages_.size());
     JsonObject                 root     = response->getRoot();
     JsonArray                  log      = root.createNestedArray("events");
 

--- a/src/web/WebStatusService.cpp
+++ b/src/web/WebStatusService.cpp
@@ -129,19 +129,22 @@ void WebStatusService::webStatusService(AsyncWebServerRequest * request) {
     AsyncJsonResponse * response = new AsyncJsonResponse(false, EMSESP_JSON_SIZE_MEDIUM_DYN);
     JsonObject          root     = response->getRoot();
 
-    root["status"]         = EMSESP::bus_status();    // 0, 1 or 2
-    root["num_devices"]    = EMSESP::count_devices(); // excluding Controller
-    root["num_sensors"]    = EMSESP::dallassensor_.no_sensors();
-    root["num_analogs"]    = EMSESP::analogsensor_.no_sensors();
-    root["tx_mode"]        = EMSESP::txservice_.tx_mode();
-    root["rx_received"]    = EMSESP::rxservice_.telegram_count();
-    root["tx_sent"]        = EMSESP::txservice_.telegram_read_count() + EMSESP::txservice_.telegram_write_count();
-    root["rx_quality"]     = EMSESP::rxservice_.quality();
-    root["tx_quality"]     = EMSESP::txservice_.quality();
-    root["rx_fails"]       = EMSESP::rxservice_.telegram_error_count();
-    root["tx_fails"]       = EMSESP::txservice_.telegram_fail_count();
-    root["sensor_fails"]   = EMSESP::dallassensor_.fails();
-    root["sensor_reads"]   = EMSESP::dallassensor_.reads();
+    root["status"]           = EMSESP::bus_status();    // 0, 1 or 2
+    root["num_devices"]      = EMSESP::count_devices(); // excluding Controller
+    root["num_sensors"]      = EMSESP::dallassensor_.no_sensors();
+    root["num_analogs"]      = EMSESP::analogsensor_.no_sensors();
+    root["tx_mode"]          = EMSESP::txservice_.tx_mode();
+    root["rx_received"]      = EMSESP::rxservice_.telegram_count();
+    root["tx_reads"]         = EMSESP::txservice_.telegram_read_count();
+    root["tx_writes"]        = EMSESP::txservice_.telegram_write_count();
+    root["rx_quality"]       = EMSESP::rxservice_.quality();
+    root["tx_read_quality"]  = EMSESP::txservice_.read_quality();
+    root["tx_write_quality"] = EMSESP::txservice_.write_quality();
+    root["rx_fails"]         = EMSESP::rxservice_.telegram_error_count();
+    root["tx_read_fails"]    = EMSESP::txservice_.telegram_read_fail_count();
+    root["tx_write_fails"]   = EMSESP::txservice_.telegram_write_fail_count();
+    root["sensor_fails"]     = EMSESP::dallassensor_.fails();
+    root["sensor_reads"]     = EMSESP::dallassensor_.reads();
     root["sensor_quality"] = EMSESP::dallassensor_.reads() == 0 ? 100 : 100 - (uint8_t)((100 * EMSESP::dallassensor_.fails()) / EMSESP::dallassensor_.reads());
     root["analog_fails"]   = EMSESP::analogsensor_.fails();
     root["analog_reads"]   = EMSESP::analogsensor_.reads();


### PR DESCRIPTION
I've also added a warning for mqtt queue overflow
Texts are not the same in Web / system info / console and heartbeat. I don't wat to change too much.
I've tried with colored device handlers (commented out), but i think few lines more are clearer.
Check the publish_value. I think the visibilty should  affect this too.
Check generate_values, the bool-HA format as strings: afaik HA uses only mqtt, or does it affect api too?
in #300 there was a weblog buffer overflow. I've changed the memory allocation to buffered messages and a bit larger in maximum.