### PR TITLE
helptext for string commands

### DIFF
--- a/interface/src/project/DashboardData.tsx
+++ b/interface/src/project/DashboardData.tsx
@@ -14,6 +14,7 @@ import {
   DialogActions,
   MenuItem,
   InputAdornment,
+  FormHelperText,
   IconButton,
   List,
   ListItem,
@@ -247,6 +248,9 @@ const DashboardData: FC = () => {
                   startAdornment: <InputAdornment position="start">{DeviceValueUOM_s[deviceValue.u]}</InputAdornment>
                 }}
               />
+            )}
+            {deviceValue.h && (
+              <FormHelperText>{deviceValue.h}</FormHelperText>
             )}
           </DialogContent>
           <DialogActions>

--- a/interface/src/project/types.ts
+++ b/interface/src/project/types.ts
@@ -131,6 +131,7 @@ export interface DeviceValue {
   n: string; // name
   c: string; // command
   l: string[]; // list
+  h?: string; // help text
 }
 
 export interface DeviceData {

--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -737,9 +737,9 @@ void EMSdevice::generate_values_web(JsonObject & output) {
                     l.add("off");
                     l.add("on");
                 }
-                // add command template
+                // add command help template
                 if ((dv.type == DeviceValueType::STRING || dv.type == DeviceValueType::CMD) && dv.options_size == 1) {
-                    obj["o"] = dv.options[0];
+                    obj["h"] = dv.options[0];
                 }
             }
         }


### PR DESCRIPTION
This is a small addition for a few  commands that needs a special formats, like thermostat datetime, switchtime, and holidays. 
Looks like this: 
![Screenshot 2022-01-24 at 17-55-28 EMS-ESP](https://user-images.githubusercontent.com/59284019/150830050-3c506a7d-b67b-463d-b30f-d2407800e319.png)
![Screenshot 2022-01-24 at 17-56-33 EMS-ESP](https://user-images.githubusercontent.com/59284019/150830066-9df8b9c2-028f-4b8d-b256-828f70940919.png)


Check if you ike it.