### PR TITLE
fix #329, numberformat in Edge, Chrome

### DIFF
--- a/interface/src/project/DashboardData.tsx
+++ b/interface/src/project/DashboardData.tsx
@@ -239,7 +239,7 @@ const DashboardData: FC = () => {
               <ValidatedTextField
                 name="v"
                 label={deviceValue.n}
-                value={deviceValue.u ? Intl.NumberFormat().format(deviceValue.v) : deviceValue.v}
+                value={deviceValue.v}
                 autoFocus
                 sx={{ width: '30ch' }}
                 type={deviceValue.u ? 'number' : 'text'}

--- a/interface/src/project/DashboardData.tsx
+++ b/interface/src/project/DashboardData.tsx
@@ -239,7 +239,7 @@ const DashboardData: FC = () => {
               <ValidatedTextField
                 name="v"
                 label={deviceValue.n}
-                value={deviceValue.v}
+                value={deviceValue.u ? numberValue(deviceValue.v) : deviceValue.v}
                 autoFocus
                 sx={{ width: '30ch' }}
                 type={deviceValue.u ? 'number' : 'text'}


### PR DESCRIPTION
Seems Chrome and Edge dont like Intl.NumerFormat() in this place. Now it works here with Edge/win10, Chrome/Android.