### PR TITLE
fix #336, map Junkers hc3/4 to masterthermostat

### DIFF
--- a/src/device_library.h
+++ b/src/device_library.h
@@ -101,6 +101,8 @@
 {106, DeviceType::THERMOSTAT, F("FW200"), DeviceFlags::EMS_DEVICE_FLAG_JUNKERS},
 {107, DeviceType::THERMOSTAT, F("FR100"), DeviceFlags::EMS_DEVICE_FLAG_JUNKERS | DeviceFlags::EMS_DEVICE_FLAG_JUNKERS_OLD}, // older model
 {108, DeviceType::THERMOSTAT, F("FR110"), DeviceFlags::EMS_DEVICE_FLAG_JUNKERS | DeviceFlags::EMS_DEVICE_FLAG_JUNKERS_OLD}, // older model
+{109, DeviceType::THERMOSTAT, F("FB10"), DeviceFlags::EMS_DEVICE_FLAG_JUNKERS},
+{110, DeviceType::THERMOSTAT, F("FB100"), DeviceFlags::EMS_DEVICE_FLAG_JUNKERS},
 {111, DeviceType::THERMOSTAT, F("FR10"), DeviceFlags::EMS_DEVICE_FLAG_JUNKERS | DeviceFlags::EMS_DEVICE_FLAG_JUNKERS_OLD}, // older model
 {147, DeviceType::THERMOSTAT, F("FR50"), DeviceFlags::EMS_DEVICE_FLAG_JUNKERS | DeviceFlags::EMS_DEVICE_FLAG_JUNKERS_OLD},
 {191, DeviceType::THERMOSTAT, F("FR120"), DeviceFlags::EMS_DEVICE_FLAG_JUNKERS | DeviceFlags::EMS_DEVICE_FLAG_JUNKERS_OLD}, // older model

--- a/src/locale_EN.h
+++ b/src/locale_EN.h
@@ -375,7 +375,7 @@ MAKE_PSTR_LIST(enum_controlmode, F_(off), F_(optimized), F_(simple), F_(mpc), F_
 MAKE_PSTR_LIST(enum_controlmode2, F_(outdoor), F_(room))
 // MAKE_PSTR_LIST(enum_controlmode3, F_(off), F_(room), F_(outdoor), F("room+outdoor"))
 MAKE_PSTR_LIST(enum_control, F_(off), F_(rc20), F_(rc3x))
-MAKE_PSTR_LIST(enum_j_control, F_(off), F("fb10"), F("fb110"))
+MAKE_PSTR_LIST(enum_j_control, F_(off), F("fb10"), F("fb100"))
 
 MAKE_PSTR_LIST(enum_wwProgMode, F("std_prog"), F_(own_prog))
 MAKE_PSTR_LIST(enum_dayOfWeek, F("mo"), F("tu"), F("we"), F("th"), F("fr"), F("sa"), F("so"), F("all"))

--- a/src/telegram.cpp
+++ b/src/telegram.cpp
@@ -359,8 +359,9 @@ void TxService::send_telegram(const QueuedTxTelegram & tx_telegram) {
             telegram_raw[message_p++] = telegram->message_data[i];
         }
     }
-
-    telegram_last_ = std::make_shared<Telegram>(*telegram); // make a copy of the telegram
+    // make a copy of the telegram with new dest
+    telegram_last_ =
+        std::make_shared<Telegram>(telegram->operation, telegram->src, dest, telegram->type_id, telegram->offset, telegram->message_data, telegram->message_length);
 
     uint8_t length       = message_p;
     telegram_raw[length] = calculate_crc(telegram_raw, length); // generate and append CRC to the end


### PR DESCRIPTION
These are the changes to map the hc thermostat to masterthermostat in the logic we have already. To register multible thermostats needs more changes to handle multible same-name parameters and commands that are not hc dependend (ww/clock/temp-sensor).