### PR TITLE
show correct hostname in startup message

### DIFF
--- a/src/dallassensor.cpp
+++ b/src/dallassensor.cpp
@@ -535,7 +535,7 @@ std::string DallasSensor::Sensor::name() const {
 bool DallasSensor::Sensor::apply_customization() {
     EMSESP::webCustomizationService.read([&](WebCustomization & settings) {
         auto sensors = settings.sensorCustomizations;
-        if (sensors.empty()) {
+        if (!sensors.empty()) {
             for (const auto & sensor : sensors) {
 #if defined(EMSESP_DEBUG)
                 LOG_DEBUG(F("Loading customization for dallas sensor %s"), sensor.id_str.c_str());

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -1370,7 +1370,6 @@ void EMSESP::start() {
 
     esp8266React.begin();  // loads core system services settings (network, mqtt, ap, ntp etc)
     webLogService.begin(); // start web log service. now we can start capturing logs to the web log
-    LOG_INFO(F("Starting EMS-ESP version %s (hostname: %s)"), EMSESP_APP_VERSION, system_.hostname().c_str()); // welcome message
     LOG_INFO(F("Last system reset reason Core0: %s, Core1: %s"), system_.reset_reason(0).c_str(), system_.reset_reason(1).c_str());
 
     webSettingsService.begin();      // load EMS-ESP Application settings...
@@ -1385,8 +1384,10 @@ void EMSESP::start() {
     system_.check_upgrade(); // do any system upgrades
 
     // start all the EMS-ESP services
-    mqtt_.start();         // mqtt init
-    system_.start();       // starts commands, led, adc, button, network, syslog & uart
+    mqtt_.start();   // mqtt init
+    system_.start(); // starts commands, led, adc, button, network, syslog & uart
+    LOG_INFO(F("Starting EMS-ESP version %s (hostname: %s)"), EMSESP_APP_VERSION, system_.hostname().c_str()); // welcome message
+
     shower_.start();       // initialize shower timer and shower alert
     dallassensor_.start(); // Dallas external sensors
     analogsensor_.start(); // Analog external sensors


### PR DESCRIPTION
for the mDNS test i've changed the hostname and wonder why the startup message always show `ems-esp`. The hostname is set in system_start(), so move the startup-message after system_.start(), or set the hostname earlier, or do not mention hostaname in this message? This PR is first option.