### PR TITLE
remove `(hidden)` text, force exclude from web icon

### DIFF
--- a/interface/src/project/SettingsCustomization.tsx
+++ b/interface/src/project/SettingsCustomization.tsx
@@ -186,13 +186,13 @@ const SettingsCustomization: FC = () => {
 
     const getMask = (de: DeviceEntity) => {
       var new_masks = [];
-      if ((de.m & 1) === 1) {
+      if ((de.m & 1) === 1 || de.n === '') {
         new_masks.push('1');
       }
       if ((de.m & 2) === 2) {
         new_masks.push('2');
       }
-      if ((de.m & 4) === 4) {
+      if ((de.m & 4) === 4 && de.w) {
         new_masks.push('4');
       }
       if ((de.m & 8) === 8) {
@@ -223,7 +223,7 @@ const SettingsCustomization: FC = () => {
                     setMask(de, mask);
                   }}
                 >
-                  <ToggleButton value="8" color="success" disabled={(de.m & 1) !== 0}>
+                  <ToggleButton value="8" color="success" disabled={(de.m & 1) !== 0 || de.n === ''}>
                     <FavoriteBorderOutlinedIcon fontSize="small" />
                   </ToggleButton>
                   <ToggleButton value="4" disabled={!de.w}>

--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -831,7 +831,7 @@ void EMSdevice::generate_values_web_all(JsonArray & output) {
                 obj["n"] = name;
             }
         } else {
-            obj["n"] = "(hidden)";
+            obj["n"] = "";
         }
 
         // shortname


### PR DESCRIPTION
the extra check `if ((de.m & 4) === 4 && de.w)` is to remove a possible 07-flag from b9-version (where all was flagged 07).