### PR TITLE
try to fix #408 and #412

### DIFF
--- a/lib/framework/NTPSettingsService.cpp
+++ b/lib/framework/NTPSettingsService.cpp
@@ -46,8 +46,10 @@ void NTPSettingsService::WiFiEvent(WiFiEvent_t event) {
 
 // https://werner.rothschopf.net/microcontroller/202103_arduino_esp32_ntp_en.htm
 void NTPSettingsService::configureNTP() {
+    emsesp::EMSESP::system_.ntp_connected(false);
     if (connected_ && _state.enabled) {
         emsesp::EMSESP::logger().info(F("Starting NTP"));
+        sntp_set_time_sync_notification_cb(ntp_received);
         configTzTime(_state.tzFormat.c_str(), _state.server.c_str());
     } else {
         setenv("TZ", _state.tzFormat.c_str(), 1);
@@ -74,4 +76,9 @@ void NTPSettingsService::configureTime(AsyncWebServerRequest * request, JsonVari
 
     AsyncWebServerResponse * response = request->beginResponse(400);
     request->send(response);
+}
+
+void NTPSettingsService::ntp_received(struct timeval * tv) {
+    // emsesp::EMSESP::logger().info(F("NTP sync to %d sec"), tv->tv_sec);
+    emsesp::EMSESP::system_.ntp_connected(true);
 }

--- a/lib/framework/NTPSettingsService.h
+++ b/lib/framework/NTPSettingsService.h
@@ -57,6 +57,7 @@ class NTPSettingsService : public StatefulService<NTPSettings> {
     NTPSettingsService(AsyncWebServer * server, FS * fs, SecurityManager * securityManager);
 
     void begin();
+    static void ntp_received(struct timeval * tv);
 
   private:
     HttpEndpoint<NTPSettings>   _httpEndpoint;
@@ -67,6 +68,7 @@ class NTPSettingsService : public StatefulService<NTPSettings> {
     void WiFiEvent(WiFiEvent_t event);
     void configureNTP();
     void configureTime(AsyncWebServerRequest * request, JsonVariant & json);
+
 };
 
 #endif

--- a/lib/framework/NTPStatus.cpp
+++ b/lib/framework/NTPStatus.cpp
@@ -1,4 +1,5 @@
 #include <NTPStatus.h>
+#include "../../src/emsesp_stub.hpp" // proddy added
 
 using namespace std::placeholders; // for `_1` etc
 
@@ -35,7 +36,7 @@ void NTPStatus::ntpStatus(AsyncWebServerRequest * request) {
     time_t now = time(nullptr);
 
     // only provide enabled/disabled status for now
-    root["status"] = sntp_enabled() ? 1 : 0;
+    root["status"] = sntp_enabled() && emsesp::EMSESP::system_.ntp_connected() ? 1 : 0;
 
     // the current time in UTC
     root["utc_time"] = toUTCTimeString(gmtime(&now));

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1080,6 +1080,7 @@ bool System::command_info(const char * value, const int8_t id, JsonObject & outp
     node["version"]          = EMSESP_APP_VERSION;
     node["uptime"]           = uuid::log::format_timestamp_ms(uuid::get_uptime_ms(), 3);
     node["uptime (seconds)"] = uuid::get_uptime_sec();
+    node["network time"]     = EMSESP::system_.ntp_connected() ? "connected" : "disconnected";
 
 #ifndef EMSESP_STANDALONE
     node["freemem"] = ESP.getFreeHeap() / 1000L; // kilobytes

--- a/src/system.h
+++ b/src/system.h
@@ -154,6 +154,17 @@ class System {
         ethernet_connected_ = b;
     }
 
+    void ntp_connected(bool b) {
+        ntp_connected_  = b;
+        ntp_last_check_ = b ? uuid::get_uptime_sec() : 0;
+    }
+
+    bool ntp_connected() {
+        // timeout 2 hours, ntp sync is normally every hour.
+        ntp_connected_ = (uuid::get_uptime_sec() - ntp_last_check_ > 7201) ? false : ntp_connected_;
+        return ntp_connected_;
+    }
+
     bool network_connected() {
 #ifndef EMSESP_STANDALONE
         return (ethernet_connected() || WiFi.isConnected());
@@ -217,6 +228,9 @@ class System {
 
     bool upload_status_      = false; // true if we're in the middle of a OTA firmware upload
     bool ethernet_connected_ = false;
+
+    bool     ntp_connected_  = false;
+    uint32_t ntp_last_check_ = 0;
 
     // EMS-ESP settings
     // copies from WebSettings class in WebSettingsService.h and loaded with reload_settings()


### PR DESCRIPTION
As mentioned i can not reproduce the issues, but the ntp status shows only if there is ntp service configured, not if ntp time is received. So a typo in server name shows active, but time is not set. 
With this commit i check if ntp time is realy received within the last 2 hours (ntp updates every hour). So the status can be checked on web page (network time -> status) and in system/info from api. 
Should we also add it to mqtt (heartbeat) and/or log changes in ntp state?