### PR TITLE
add NTP status to mqtt/ha (heartbeat) and log

### DIFF
--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -648,6 +648,7 @@ void Mqtt::ha_status() {
     }
     publish_system_ha_sensor_config(DeviceValueType::INT, F("Uptime"), F("uptime"), DeviceValueUOM::NONE);
     publish_system_ha_sensor_config(DeviceValueType::INT, F("Uptime (sec)"), F("uptime_sec"), DeviceValueUOM::SECONDS);
+    publish_system_ha_sensor_config(DeviceValueType::BOOL, F("NTP status"), F("ntp_status"), DeviceValueUOM::NONE);
     publish_system_ha_sensor_config(DeviceValueType::INT, F("Free memory"), F("freemem"), DeviceValueUOM::KB);
     publish_system_ha_sensor_config(DeviceValueType::INT, F("MQTT fails"), F("mqttfails"), DeviceValueUOM::NONE);
     publish_system_ha_sensor_config(DeviceValueType::INT, F("Rx received"), F("rxreceived"), DeviceValueUOM::NONE);

--- a/src/system.h
+++ b/src/system.h
@@ -154,14 +154,13 @@ class System {
         ethernet_connected_ = b;
     }
 
-    void ntp_connected(bool b) {
-        ntp_connected_  = b;
-        ntp_last_check_ = b ? uuid::get_uptime_sec() : 0;
-    }
+    void ntp_connected(bool b);
 
     bool ntp_connected() {
         // timeout 2 hours, ntp sync is normally every hour.
-        ntp_connected_ = (uuid::get_uptime_sec() - ntp_last_check_ > 7201) ? false : ntp_connected_;
+        if ((uuid::get_uptime_sec() - ntp_last_check_ > 7201) && ntp_connected_) {
+            ntp_connected(false);
+        }
         return ntp_connected_;
     }
 


### PR DESCRIPTION
I think it's better to have it logged and also in mqtt. Here is a log if wifi is reconnected:
```
2022-03-29 18:32:19.809 I 19: [mqtt] MQTT disconnected: TCP
2022-03-29 18:32:22.949 I 20: [system] NTP disconnected
2022-03-29 18:32:22.949 I 21: [emsesp] Starting NTP
2022-03-29 18:32:22.949 I 22: [emsesp] WiFi connected with IP=192.168.0.116, hostname=ems-esp
2022-03-29 18:32:22.991 I 23: [system] NTP connected
2022-03-29 18:32:23.009 I 24: [mqtt] MQTT connected
```