### PR TITLE
fix changing masks for customizations

### DIFF
--- a/interface/src/project/SettingsCustomization.tsx
+++ b/interface/src/project/SettingsCustomization.tsx
@@ -161,7 +161,7 @@ const SettingsCustomization: FC = () => {
   const saveCustomization = async () => {
     if (deviceEntities && selectedDevice) {
       const masked_entities = deviceEntities
-        .filter((de) => de.m)
+        // .filter((de) => de.m)
         .map((new_de) => new_de.m.toString(16).padStart(2, '0') + new_de.s);
       try {
         const response = await EMSESP.writeMaskedEntities({

--- a/interface/src/project/types.ts
+++ b/interface/src/project/types.ts
@@ -131,10 +131,10 @@ export interface DeviceValue {
   n: string; // name
   c: string; // command
   l: string[]; // list
-  h?: string; // help text
-  s?: string; // steps for up/down
-  m?: string; // min
-  x?: string; // max
+  h?: string; // help text, optional
+  s?: string; // steps for up/down, optional
+  m?: string; // min, optional
+  x?: string; // max, optional
 }
 
 export interface DeviceData {
@@ -147,7 +147,7 @@ export interface DeviceEntity {
   n: string; // name
   s: string; // shortname
   m: number; // mask
-  w?: boolean; // writeable
+  w: boolean; // writeable
 }
 
 export interface MaskedEntities {

--- a/src/emsdevice.h
+++ b/src/emsdevice.h
@@ -183,8 +183,7 @@ class EMSdevice {
     char * show_telegram_handlers(char * result, const size_t len, const uint8_t handlers);
     void   show_mqtt_handlers(uuid::console::Shell & shell) const;
     void   list_device_entries(JsonObject & output) const;
-    void   mask_entity(const std::string & entity_id);
-    void   reset_entity_masks();
+    bool   mask_entity(const std::string & entity_id);
 
     using process_function_p = std::function<void(std::shared_ptr<const Telegram>)>;
 

--- a/src/emsdevicevalue.cpp
+++ b/src/emsdevicevalue.cpp
@@ -134,7 +134,7 @@ size_t DeviceValue::tag_count = sizeof(DeviceValue::DeviceValueTAG_s) / sizeof(_
 // checks whether the device value has an actual value
 // returns true if its valid
 // state is stored in the dv object
-bool DeviceValue::hasValue() {
+bool DeviceValue::hasValue() const {
     bool has_value = false;
     switch (type) {
     case DeviceValueType::BOOL:

--- a/src/emsdevicevalue.h
+++ b/src/emsdevicevalue.h
@@ -168,20 +168,20 @@ class DeviceValue {
         , state(state) {
     }
 
-    bool hasValue();
+    bool hasValue() const;
     bool get_min_max(int16_t & dv_set_min, int16_t & dv_set_max);
 
     // state flags
-    inline void add_state(uint8_t s) {
+    void add_state(uint8_t s) {
         state |= s;
     }
-    inline bool has_state(uint8_t s) const {
+    bool has_state(uint8_t s) const {
         return (state & s) == s;
     }
-    inline void remove_state(uint8_t s) {
+    void remove_state(uint8_t s) {
         state &= ~s;
     }
-    inline uint8_t get_state() const {
+    uint8_t get_state() const {
         return state;
     }
 

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -919,6 +919,10 @@ void Mqtt::publish_ha_sensor_config(DeviceValue & dv, const std::string & model,
     int16_t dv_set_min, dv_set_max;
     (void)dv.get_min_max(dv_set_min, dv_set_max);
 
+    // determine if we're creating the command topics which we use special HA configs
+    // unless the entity has been marked as read-only and so it'll default to using the sensor/ type
+    bool has_cmd = dv.has_cmd && !dv.has_state(DeviceValueState::DV_READONLY);
+
     publish_ha_sensor_config(dv.type,
                              dv.tag,
                              dv.full_name,
@@ -926,7 +930,7 @@ void Mqtt::publish_ha_sensor_config(DeviceValue & dv, const std::string & model,
                              dv.short_name,
                              dv.uom,
                              remove,
-                             dv.has_cmd && !dv.has_state(DeviceValueState::DV_READONLY),
+                             has_cmd,
                              dv.options,
                              dv.options_size,
                              dv_set_min,

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define EMSESP_APP_VERSION "3.4.0b10"
+#define EMSESP_APP_VERSION "3.4.0b11"

--- a/src/web/WebCustomizationService.cpp
+++ b/src/web/WebCustomizationService.cpp
@@ -172,11 +172,10 @@ void WebCustomizationService::devices(AsyncWebServerRequest * request) {
             obj["i"]       = emsdevice->unique_id(); // a unique id
 
             /*
-            // shortname - we prefix the count to make it unique
             uint8_t device_index = EMSESP::device_index(emsdevice->device_type(), emsdevice->unique_id());
             if (device_index) {
                 char s[10];
-                obj["s"] = emsdevice->device_type_name() + Helpers::smallitoa(s, device_index) + " (" + emsdevice->name() + ")";
+                obj["s"] = emsdevice->device_type_name() + Helpers::smallitoa(s, device_index) + " (" + emsdevice->name() + ")";  // shortname - we prefix the count to make it unique
             } else {
                 obj["s"] = emsdevice->device_type_name() + " (" + emsdevice->name() + ")";
             }
@@ -221,16 +220,16 @@ void WebCustomizationService::masked_entities(AsyncWebServerRequest * request, J
             if (emsdevice) {
                 uint8_t unique_device_id = json["id"];
                 if (emsdevice->unique_id() == unique_device_id) {
-                    // first reset all the entity ids
-                    emsdevice->reset_entity_masks();
-
                     // build a list of entities
                     JsonArray                entity_ids_json = json["entity_ids"];
                     std::vector<std::string> entity_ids;
-                    for (JsonVariant id : entity_ids_json) {
+                    for (const JsonVariant id : entity_ids_json) {
                         std::string entity_id = id.as<std::string>();
-                        emsdevice->mask_entity(entity_id); // this will have immediate affect
-                        entity_ids.push_back(entity_id);
+                        // handle the mask change and add to the list of customized entities
+                        // if the value is different from the default (mask == 0)
+                        if (emsdevice->mask_entity(entity_id)) {
+                            entity_ids.push_back(entity_id);
+                        }
                     }
 
                     // Save the list to the customization file


### PR DESCRIPTION
saving customizations would re-create some MQTT topics and also not remove them correctly when a mask was toggled off. I fixed this by now sending the complete list of entities & masks to the server and let the server determine whether it needs to change the dv.state and remove any left over HA configs.