### PR TITLE
changes per #444

### DIFF
--- a/interface/src/framework/system/FirmwareFileUpload.tsx
+++ b/interface/src/framework/system/FirmwareFileUpload.tsx
@@ -19,7 +19,6 @@ const FirmwareFileUpload: FC<UploadFirmwareProps> = ({ uploadFirmware }) => {
         my={2}
       />
       <SingleUpload
-        // accept="application/octet-stream"
         accept=".bin"
         onDrop={uploadFile}
         onCancel={cancelUpload}

--- a/interface/src/project/api.ts
+++ b/interface/src/project/api.ts
@@ -83,7 +83,6 @@ export function resetCustomizations(): AxiosPromise<void> {
   return AXIOS.post('/resetCustomizations');
 }
 
-// EMS-ESP API calls
 export function API(apiCall: APIcall): AxiosPromise<void> {
   return AXIOS_API.post('/', apiCall);
 }

--- a/interface/src/project/types.ts
+++ b/interface/src/project/types.ts
@@ -147,6 +147,7 @@ export interface DeviceEntity {
   n: string; // name
   s: string; // shortname
   m: number; // mask
+  om?: number; // original mask before edits
   w: boolean; // writeable
 }
 

--- a/mock-api/server.js
+++ b/mock-api/server.js
@@ -948,6 +948,7 @@ function updateMask(entity, de, dd) {
 
 rest_server.post(EMSESP_MASKED_ENTITIES_ENDPOINT, (req, res) => {
   const id = req.body.id
+  console.log(req.body.entity_ids)
   for (const entity of req.body.entity_ids) {
     if (id === 1) {
       updateMask(entity, emsesp_deviceentities_1, emsesp_devicedata_1)

--- a/src/devices/solar.h
+++ b/src/devices/solar.h
@@ -234,7 +234,6 @@ class Solar : public EMSdevice {
     bool set_wwKeepWarm(const char * value, const int8_t id);
     bool set_wwDisinfectionTemp(const char * value, const int8_t id);
     bool set_wwDailyTemp(const char * value, const int8_t id);
-
 };
 
 } // namespace emsesp

--- a/src/web/WebCustomizationService.cpp
+++ b/src/web/WebCustomizationService.cpp
@@ -215,7 +215,7 @@ void WebCustomizationService::device_entities(AsyncWebServerRequest * request, J
 // and updates the entity list real-time
 void WebCustomizationService::masked_entities(AsyncWebServerRequest * request, JsonVariant & json) {
     if (json.is<JsonObject>()) {
-        EMSESP::logger().debug(F("Masked entities json size: %d"), measureJson(json));
+        // EMSESP::logger().debug(F("Masked entities json size: %d"), measureJson(json));
         // find the device using the unique_id
         for (const auto & emsdevice : EMSESP::emsdevices) {
             if (emsdevice) {
@@ -226,17 +226,16 @@ void WebCustomizationService::masked_entities(AsyncWebServerRequest * request, J
                     std::vector<std::string> entity_ids;
                     for (const JsonVariant id : entity_ids_json) {
                         std::string entity_id = id.as<std::string>();
-                        // handle the mask change and add to the list of customized entities
-                        // if the value is different from the default (mask == 0)
+                        // set the new mask and add to the list of customized entities if the value is different from the default (mask == 0)
                         if (emsdevice->mask_entity(entity_id)) {
                             entity_ids.push_back(entity_id);
                         }
                     }
 
-                    // Save the list to the customization file
                     uint8_t product_id = emsdevice->product_id();
                     uint8_t device_id  = emsdevice->device_id();
 
+                    // Save the list to the customization file
                     EMSESP::webCustomizationService.update(
                         [&](WebCustomization & settings) {
                             // if it exists (productid and deviceid match) overwrite it


### PR DESCRIPTION
only send back entities that have changed, by saving the old state of the mask flag. This fixes the problem when the mask is reset in the customization UI (to 0) and it's not sent back to the server