### PR TITLE
Cell height for multiline values

### DIFF
--- a/interface/src/project/DashboardData.tsx
+++ b/interface/src/project/DashboardData.tsx
@@ -166,7 +166,7 @@ const DashboardData: FC = () => {
     BaseRow: `
       font-size: 14px;
       color: white;
-      height: 32px;
+      min-height: 32px;
     `,
     HeaderRow: `
       text-transform: uppercase;

--- a/interface/src/project/SettingsCustomization.tsx
+++ b/interface/src/project/SettingsCustomization.tsx
@@ -62,7 +62,7 @@ const SettingsCustomization: FC = () => {
     BaseRow: `
       font-size: 14px;
       color: white;
-      height: 32px;
+      min-height: 32px;
     `,
     HeaderRow: `
       text-transform: uppercase;
@@ -435,7 +435,7 @@ const SettingsCustomization: FC = () => {
                       NAME
                     </Button>
                   </HeaderCell>
-                  <HeaderCell>VALUE</HeaderCell>
+                  <HeaderCell resize>VALUE</HeaderCell>
                   <HeaderCell />
                 </HeaderRow>
               </Header>


### PR DESCRIPTION
some long text strings are shown multiline and need a larger cell:
![grafik](https://user-images.githubusercontent.com/59284019/165109776-89f7ee6e-5312-46be-9b8f-6b853349bdb2.png)
