### PR TITLE
api entitiy attributes with hcs

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -193,17 +193,22 @@ const char * Command::parse_command_string(const char * command, int8_t & id) {
         return nullptr;
     }
 
-    if (!strncmp(command, "hc", 2) && strlen(command) >= 3) {
+    // check prefix and valid number range, also check 'id'
+    if (!strncmp(command, "hc", 2) && command[2] >= '1' && command[2] <= '8') {
         id = command[2] - '0';
         command += 3;
-    } else if (!strncmp(command, "wwc", 3) && strlen(command) >= 4) {
-        if (command[3] == '1' && command[4] == '0') {
-            id = 19; // wwc10
-            command += 5;
-        } else {
-            id = command[3] - '0' + 8; // wwc1 has id 9
-            command += 4;
-        }
+    } else if (!strncmp(command, "wwc", 3) && command[3] == '1' && command[4] == '0') {
+        id = 19;
+        command += 5;
+    } else if (!strncmp(command, "wwc", 3) && command[3] >= '1' && command[3] <= '9') {
+        id = command[3] - '0' + 8;
+        command += 4;
+    } else if (!strncmp(command, "id", 2) && command[2] == '1' && command[3] >= '0' && command[3] <= '9') {
+        id = command[3] - '0' + 10;
+        command += 4;
+    } else if (!strncmp(command, "id", 2) && command[2] >= '1' && command[2] <= '9') {
+        id = command[2] - '0';
+        command += 3;
     }
     // remove separator
     if (command[0] == '/' || command[0] == '.' || command[0] == '_') {

--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -912,16 +912,13 @@ bool EMSdevice::get_value_info(JsonObject & output, const char * cmd, const int8
     // make a copy of the string command for parsing
     char command_s[30];
     strlcpy(command_s, cmd, sizeof(command_s));
-    char * attribute_s = command_s;
+    char * attribute_s = nullptr;
 
-    // if id=0 then we have a specific attribute to fetch instead of the complete record
-    if (id == 0) {
-        char * p      = command_s;
-        char * breakp = strchr(p, '/');
-        if (breakp) {
-            *breakp     = '\0';
-            attribute_s = breakp + 1;
-        }
+    // check specific attribute to fetch instead of the complete record
+    char * breakp = strchr(command_s, '/');
+    if (breakp) {
+        *breakp     = '\0';
+        attribute_s = breakp + 1;
     }
 
     // search device value with this tag
@@ -1065,8 +1062,8 @@ bool EMSdevice::get_value_info(JsonObject & output, const char * cmd, const int8
                 json[value] = "not set";
             }
 
-            // if id is 0 then we're filtering on an attribute, go find it
-            if (id == 0) {
+            // if we're filtering on an attribute, go find it
+            if (attribute_s) {
 #if defined(EMSESP_DEBUG)
                 EMSESP::logger().debug(F("[DEBUG] Attribute '%s'"), attribute_s);
 #endif


### PR DESCRIPTION
I had to change the `parse_command_string` to allow `api/device/hcx` without command. Check if i have missed something.

While testing i see that analog and dallas also needs this addition. 