### PR TITLE
Added support for ESP32-S2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -92,3 +92,14 @@ board_upload.flash_size = 4MB
 board_build.partitions = esp32_partition_4M.csv
 build_flags = ${common.build_flags}
 build_unflags = ${common.unbuild_flags}
+
+[env:lolin_s2_mini]
+extra_scripts =
+ # pre:scripts/build_interface.py
+  scripts/rename_fw.py
+board = lolin_s2_mini
+platform = espressif32
+board_upload.flash_size = 4MB
+board_build.partitions = esp32_partition_4M.csv
+build_flags = ${common.build_flags}
+build_unflags = ${common.unbuild_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -95,7 +95,7 @@ build_unflags = ${common.unbuild_flags}
 
 [env:lolin_s2_mini]
 extra_scripts =
- # pre:scripts/build_interface.py
+  pre:scripts/build_interface.py
   scripts/rename_fw.py
 board = lolin_s2_mini
 platform = espressif32

--- a/scripts/rename_fw.py
+++ b/scripts/rename_fw.py
@@ -18,6 +18,7 @@ def bin_copy(source, target, env):
                     bag[var] = m.group(1)
 
     app_version = bag.get('app_version')
+    
     platform = "ESP32"
 
     # flash_size = env["PIOENV"].split('_')[1]
@@ -30,13 +31,15 @@ def bin_copy(source, target, env):
 
     # alternatively take platform from the pio target
     # platform = str(target[0]).split(os.path.sep)[2]
+    chip_target = env.get('PIOENV').upper() 
 
     print("app version: "+app_version)
+    print("chip_target: "+chip_target)
     print("platform: "+platform)
     # print("flash size: "+flash_size)
 
     # convert . to _ so Windows doesn't complain
-    variant = "EMS-ESP-" + app_version.replace(".", "_") + "-" + platform
+    variant = "EMS-ESP-" + app_version.replace(".", "_") + "-" + chip_target
 
     # variant = "EMS-ESP-" + app_version.replace(".", "_") + "-" + platform + "_" + flash_size
 

--- a/src/analogsensor.h
+++ b/src/analogsensor.h
@@ -25,7 +25,9 @@
 
 #ifndef EMSESP_STANDALONE
 #include "driver/adc.h"
+#ifndef ARDUINO_LOLIN_S2_MINI
 #include <esp_bt.h>
+#endif
 #endif
 
 #include <uuid/log.h>

--- a/src/system.h
+++ b/src/system.h
@@ -29,7 +29,9 @@
 
 #ifndef EMSESP_STANDALONE
 #include <esp_wifi.h>
+#ifndef ARDUINO_LOLIN_S2_MINI
 #include <esp_bt.h>
+#endif
 #include <ETH.h>
 #include <uuid/syslog.h>
 #endif

--- a/src/uart/emsuart_esp32.h
+++ b/src/uart/emsuart_esp32.h
@@ -26,7 +26,7 @@
 
 #define EMS_MAXBUFFERSIZE 33 // max size of the buffer. EMS packets are max 32 bytes, plus extra for BRK
 
-#ifdef ARDUINO_LOLIN_C3_MINI
+#if (defined(ARDUINO_LOLIN_C3_MINI)) || (defined(ARDUINO_LOLIN_S2_MINI))
 #define EMSUART_NUM UART_NUM_1 // on C3 mini we're using UART1
 #else
 #define EMSUART_NUM UART_NUM_2 // on the ESP32 we're using UART2


### PR DESCRIPTION
LOLIN ESP32-S2 board added to PlatformIO.ini
Changed the naming of firmware bin files, it now based on project environment name.
