### PR TITLE
Command `values` for analog/dallas sensors, writeable for analog-out,…

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -18,6 +18,7 @@
 - Add MD5 check [#637](https://github.com/emsesp/EMS-ESP32/issues/637)
 - Add more bus-ids [#673](https://github.com/emsesp/EMS-ESP32/issues/673)
 - Use HA connectivity device class for Status [#751](https://github.com/emsesp/EMS-ESP32/issues/751)
+- Add commands for analog sensors outputs
 
 ## Fixed
 
@@ -30,6 +31,8 @@
 - render mqtt float json values with trailing zero
 - removed flash strings
 - reload page after restart button is pressed
+- analog/dallas values command as list like ems-devices
+- analog/dallas HA-entities based on id
 
 ## **BREAKING CHANGES:**
 

--- a/interface/src/project/DashboardData.tsx
+++ b/interface/src/project/DashboardData.tsx
@@ -1141,7 +1141,7 @@ const DashboardData: FC = () => {
                   </Grid>
                 </>
               )}
-              {analog.t === AnalogType.DIGITAL_OUT && (analog.id === '25' || analog.id === '26') && (
+              {analog.t === AnalogType.DIGITAL_OUT && (analog.g === 25 || analog.g === 26) && (
                 <>
                   <Grid item xs={4}>
                     <ValidatedTextField
@@ -1157,7 +1157,7 @@ const DashboardData: FC = () => {
                   </Grid>
                 </>
               )}
-              {analog.t === AnalogType.DIGITAL_OUT && analog.id !== '25' && analog.id !== '26' && (
+              {analog.t === AnalogType.DIGITAL_OUT && analog.g !== 25 && analog.g !== 26 && (
                 <>
                   <Grid item xs={4}>
                     <ValidatedTextField

--- a/src/analogsensor.h
+++ b/src/analogsensor.h
@@ -43,8 +43,9 @@ class AnalogSensor {
         }
 
         std::string name() const;
-        void        set_name(const std::string & name) {
-                   name_ = name;
+
+        void set_name(const std::string & name) {
+            name_ = name;
         }
 
         uint8_t gpio() const {

--- a/src/command.h
+++ b/src/command.h
@@ -54,12 +54,12 @@ using cmd_json_function_p = std::function<bool(const char * data, const int8_t i
 class Command {
   public:
     struct CmdFunction {
-        uint8_t                   device_type_; // DeviceType::
-        uint8_t                   flags_;       // mqtt flags for command subscriptions
-        const char *              cmd_;
-        const cmd_function_p      cmdfunction_;
-        const cmd_json_function_p cmdfunction_json_;
-        const char * const *      description_;
+        uint8_t              device_type_; // DeviceType::
+        uint8_t              flags_;       // mqtt flags for command subscriptions
+        const char *         cmd_;
+        cmd_function_p       cmdfunction_;
+        cmd_json_function_p  cmdfunction_json_;
+        const char * const * description_;
 
         CmdFunction(const uint8_t             device_type,
                     const uint8_t             flags,
@@ -113,6 +113,7 @@ class Command {
     static void                   show_all(uuid::console::Shell & shell);
     static Command::CmdFunction * find_command(const uint8_t device_type, const char * cmd);
 
+    static void erase_command(const uint8_t device_type, const char * cmd);
     static void show(uuid::console::Shell & shell, uint8_t device_type, bool verbose);
     static void show_devices(uuid::console::Shell & shell);
     static bool device_has_commands(const uint8_t device_type);

--- a/src/device_library.h
+++ b/src/device_library.h
@@ -79,6 +79,7 @@
 {203, DeviceType::THERMOSTAT, "EasyControl CT200", DeviceFlags::EMS_DEVICE_FLAG_EASY | DeviceFlags::EMS_DEVICE_FLAG_NO_WRITE}, // 0x18, cannot write
 
 // Thermostat - Buderus/Nefit/Bosch specific - 0x17 / 0x10 / 0x18 / 0x19-0x1B for hc2-4 / 0x38
+{  4, DeviceType::THERMOSTAT, "UI800", DeviceFlags::EMS_DEVICE_FLAG_RC300}, // 0x10
 { 65, DeviceType::THERMOSTAT, "RC10", DeviceFlags::EMS_DEVICE_FLAG_RC20_N},// 0x17
 { 67, DeviceType::THERMOSTAT, "RC30", DeviceFlags::EMS_DEVICE_FLAG_RC30_N},// 0x10 - based on RC35
 { 77, DeviceType::THERMOSTAT, "RC20/Moduline 300", DeviceFlags::EMS_DEVICE_FLAG_RC20},// 0x17
@@ -116,6 +117,7 @@
 {192, DeviceType::THERMOSTAT, "FW120", DeviceFlags::EMS_DEVICE_FLAG_JUNKERS},
 
 // Thermostat remote - 0x38
+{  3, DeviceType::THERMOSTAT, "RT800", DeviceFlags::EMS_DEVICE_FLAG_RC100H},
 {200, DeviceType::THERMOSTAT, "RC100H", DeviceFlags::EMS_DEVICE_FLAG_RC100H},
 
 // Solar Modules - 0x30 (for solar), 0x2A, 0x41 (for ww)

--- a/src/locale_common.h
+++ b/src/locale_common.h
@@ -230,6 +230,8 @@ MAKE_PSTR_LIST(climate, "HA climate config creation")
 MAKE_PSTR_LIST(list_syslog_level, "off", "emerg", "alert", "crit", "error", "warn", "notice", "info", "debug", "trace", "all")
 
 // sensors
+MAKE_PSTR_LIST(counter, "counter")
+MAKE_PSTR_LIST(digital_out, "digital_out")
 MAKE_PSTR_LIST(list_sensortype, "none", "digital in", "counter", "adc", "timer", "rate", "digital out", "pwm 0", "pwm 1", "pwm 2")
 
 // watch


### PR DESCRIPTION
These are the changes for analog/dallas i mentioned in #758. 
/api/dallassensor now defaults to "values" and reponse a list of values, i left the info command untouched.
same for analogsensor, the outputs generate a command to name. Because these names are not lowercase the namecheck has to compare incoming and stored commandname in lowercase.
value-info for analog/dallas works with name and id, writeable is included and min/max only for commands, as for ems-entities.
Changing analog sensors removes/regenerates the commands.
I've changed the HA entity for dallas/analog to ID. 

Adding the basename to entity for #759 is your turn, you can better check and it's a breaking change for HA users.

@tp1de, i've modified your adapter to test the changes, check https://github.com/MichaelDvP/ioBroker.ems-esp (I see you have also made some changes since i've pulled)