### PR TITLE
small changes for #759

### DIFF
--- a/lib/framework/MqttSettingsService.cpp
+++ b/lib/framework/MqttSettingsService.cpp
@@ -137,7 +137,7 @@ void MqttSettingsService::configureMqtt() {
         _mqttClient.setClientId(retainCstr(_state.clientId.c_str(), &_retainedClientId));
         _mqttClient.setKeepAlive(_state.keepAlive);
         _mqttClient.setCleanSession(_state.cleanSession);
-        _mqttClient.setMaxTopicLength(_state.maxTopicLength);
+        _mqttClient.setMaxTopicLength(FACTORY_MQTT_MAX_TOPIC_LENGTH); // hardcode. We don't take this from the settings anymore.
         _mqttClient.connect();
         // } else {
         // emsesp::EMSESP::logger().info("Error configuring Mqtt client");
@@ -187,8 +187,6 @@ StateUpdateResult MqttSettings::update(JsonObject & root, MqttSettings & setting
     newSettings.cleanSession = root["clean_session"] | FACTORY_MQTT_CLEAN_SESSION;
     newSettings.mqtt_qos     = root["mqtt_qos"] | EMSESP_DEFAULT_MQTT_QOS;
     newSettings.mqtt_retain  = root["mqtt_retain"] | EMSESP_DEFAULT_MQTT_RETAIN;
-
-    newSettings.maxTopicLength = FACTORY_MQTT_MAX_TOPIC_LENGTH; // hardcode. We don't take this from the settings anymore.
 
     newSettings.publish_time_boiler     = root["publish_time_boiler"] | EMSESP_DEFAULT_PUBLISH_TIME;
     newSettings.publish_time_thermostat = root["publish_time_thermostat"] | EMSESP_DEFAULT_PUBLISH_TIME;

--- a/lib/framework/MqttSettingsService.h
+++ b/lib/framework/MqttSettingsService.h
@@ -74,7 +74,6 @@ class MqttSettings {
     // connection settings
     uint16_t keepAlive;
     bool     cleanSession;
-    uint16_t maxTopicLength;
 
     // proddy EMS-ESP specific
     String   base;

--- a/src/analogsensor.cpp
+++ b/src/analogsensor.cpp
@@ -451,7 +451,7 @@ void AnalogSensor::publish_values(const bool force) {
                 }
                 config["val_tpl"] = str;
 
-                snprintf(str, sizeof(str), "%s_analog_sensor_%s", Mqtt::basename().c_str(), sensor.name().c_str());
+                snprintf(str, sizeof(str), "%s_analogsensor_%d", Mqtt::basename().c_str(), sensor.gpio());
                 config["object_id"] = str;
                 config["uniq_id"]   = str; // same as object_id
 

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -284,12 +284,12 @@ uint8_t Command::call(const uint8_t device_type, const char * cmd, const char * 
         std::string ro = EMSESP::system_.readonly_mode() ? "[readonly] " : "";
 
         if ((value == nullptr) || (strlen(value) == 0)) {
-            LOG_INFO(("%sCalling command %s"), ro.c_str(), info_s);
+            LOG_DEBUG(("%sCalling command %s"), ro.c_str(), info_s);
         } else {
             if (id > 0) {
-                LOG_INFO(("%sCalling command %s with value %s and id %d"), ro.c_str(), info_s, value, id);
+                LOG_DEBUG(("%sCalling command %s with value %s and id %d"), ro.c_str(), info_s, value, id);
             } else {
-                LOG_INFO(("%sCalling command %s with value %s"), ro.c_str(), info_s, value);
+                LOG_DEBUG(("%sCalling command %s with value %s"), ro.c_str(), info_s, value);
             }
         }
 

--- a/src/dallassensor.cpp
+++ b/src/dallassensor.cpp
@@ -518,7 +518,7 @@ void DallasSensor::publish_values(const bool force) {
                 }
                 config["val_tpl"] = str;
 
-                snprintf(str, sizeof(str), "%s_temperature_sensor_%s", Mqtt::basename().c_str(), sensor.id().c_str());
+                snprintf(str, sizeof(str), "%s_dallassensor_%s", Mqtt::basename().c_str(), sensor.id().c_str());
                 config["object_id"] = str;
                 config["uniq_id"]   = str; // same as object_id
 

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -593,8 +593,10 @@ void Mqtt::on_connect() {
 void Mqtt::ha_status() {
     StaticJsonDocument<EMSESP_JSON_SIZE_HA_CONFIG> doc;
 
-    doc["uniq_id"]   = "ems-esp-system";
-    doc["object_id"] = "ems_esp_status";
+    char uniq[70];
+    snprintf(uniq, sizeof(uniq), "%s_status", mqtt_basename_.c_str());
+    doc["uniq_id"]   = uniq;
+    doc["object_id"] = uniq;
     doc["~"]         = mqtt_base_; // default ems-esp
     // doc["avty_t"]      = "~/status"; // commented out, as it causes errors in HA sometimes
     // doc["json_attr_t"] = "~/heartbeat"; // store also as HA attributes
@@ -614,7 +616,7 @@ void Mqtt::ha_status() {
     ids.add("ems-esp");
 
     char topic[MQTT_TOPIC_MAX_SIZE];
-    snprintf(topic, sizeof(topic), "binary_sensor/%s/system/config", mqtt_basename_.c_str());
+    snprintf(topic, sizeof(topic), "binary_sensor/%s/status/config", mqtt_basename_.c_str());
     Mqtt::publish_ha(topic, doc.as<JsonObject>()); // publish the config payload with retain flag
 
     // create the sensors - must match the MQTT payload keys


### PR DESCRIPTION
These are the changes i mentioned in your last PR:
- command logs back to debug
- use same pathname, uniq_id an object_id for analogsensor, dallassensor and status. For status the basename was also missing or fixed to ems-esp.
- entity for analogsensors back to gpio to avoid HA changes when renamed (dallas also uses ID).
- hardcode the maxTopicLength direct in mqtt-call.