### PR TITLE
Avoid blank page (NULL) as response

### DIFF
--- a/src/web/WebAPIService.cpp
+++ b/src/web/WebAPIService.cpp
@@ -101,8 +101,13 @@ void WebAPIService::parse(AsyncWebServerRequest * request, JsonObject & input) {
     }
 
     // output json buffer
-    auto *     response = new PrettyAsyncJsonResponse(false, EMSESP_JSON_SIZE_XXLARGE_DYN);
-    JsonObject output   = response->getRoot();
+    auto * response = new PrettyAsyncJsonResponse(false, EMSESP_JSON_SIZE_XXLARGE_DYN);
+    if (!response) {
+        AsyncWebServerResponse * response = request->beginResponse(507); // Insufficient Storage
+        request->send(response);
+        return;
+    }
+    JsonObject output = response->getRoot();
 
     // call command
     uint8_t return_code = Command::process(request->url().c_str(), is_admin, input, output);

--- a/src/web/WebCustomizationService.cpp
+++ b/src/web/WebCustomizationService.cpp
@@ -201,6 +201,11 @@ void WebCustomizationService::devices(AsyncWebServerRequest * request) {
 void WebCustomizationService::device_entities(AsyncWebServerRequest * request, JsonVariant & json) {
     if (json.is<JsonObject>()) {
         auto * response = new MsgpackAsyncJsonResponse(true, EMSESP_JSON_SIZE_XXXLARGE_DYN);
+        if (!response) {
+            AsyncWebServerResponse * response = request->beginResponse(507); // Insufficient Storage
+            request->send(response);
+            return;
+        }
         for (const auto & emsdevice : EMSESP::emsdevices) {
             if (emsdevice->unique_id() == json["id"]) {
 #ifndef EMSESP_STANDALONE

--- a/src/web/WebDataService.cpp
+++ b/src/web/WebDataService.cpp
@@ -166,6 +166,11 @@ void WebDataService::sensor_data(AsyncWebServerRequest * request) {
 void WebDataService::device_data(AsyncWebServerRequest * request, JsonVariant & json) {
     if (json.is<JsonObject>()) {
         auto * response = new MsgpackAsyncJsonResponse(false, EMSESP_JSON_SIZE_XXXLARGE_DYN);
+        if (!response) {
+            AsyncWebServerResponse * response = request->beginResponse(507); // Insufficient Storage
+            request->send(response);
+            return;
+        }
         for (const auto & emsdevice : EMSESP::emsdevices) {
             if (emsdevice->unique_id() == json["id"]) {
                 // wait max 2.5 sec for updated data (post_send_delay is 2 sec)


### PR DESCRIPTION
I hope this will show a red snackbar instead of blank page, but have not tested (need something to to reduce heap),
Maybe a simple `request->send(507);` will also do.