### PR TITLE
delete empty response

### DIFF
--- a/src/web/WebAPIService.cpp
+++ b/src/web/WebAPIService.cpp
@@ -103,10 +103,11 @@ void WebAPIService::parse(AsyncWebServerRequest * request, JsonObject & input) {
     // output json buffer
     auto * response = new PrettyAsyncJsonResponse(false, EMSESP_JSON_SIZE_XXLARGE_DYN);
     if (!response->getSize()) {
+        delete response;
         response = new PrettyAsyncJsonResponse(false, 256);
-        response->setCode(507);
+        response->setCode(507); // Insufficient Storage
         response->setLength();
-        request->send(response); // Insufficient Storage
+        request->send(response);
         return;
     }
     JsonObject output = response->getRoot();

--- a/src/web/WebCustomizationService.cpp
+++ b/src/web/WebCustomizationService.cpp
@@ -202,10 +202,11 @@ void WebCustomizationService::device_entities(AsyncWebServerRequest * request, J
     if (json.is<JsonObject>()) {
         auto * response = new MsgpackAsyncJsonResponse(true, EMSESP_JSON_SIZE_XXXLARGE_DYN);
         if (!response->getSize()) {
+            delete response;
             response = new MsgpackAsyncJsonResponse(true, 256);
-            response->setCode(507);
+            response->setCode(507); // Insufficient Storage
             response->setLength();
-            request->send(response); // Insufficient Storage
+            request->send(response);
             return;
         }
         for (const auto & emsdevice : EMSESP::emsdevices) {

--- a/src/web/WebDataService.cpp
+++ b/src/web/WebDataService.cpp
@@ -167,11 +167,11 @@ void WebDataService::device_data(AsyncWebServerRequest * request, JsonVariant & 
     if (json.is<JsonObject>()) {
         auto * response = new MsgpackAsyncJsonResponse(false, EMSESP_JSON_SIZE_XXXLARGE_DYN);
         if (!response->getSize()) {
-            // EMSESP::logger().err("Insufficient storage");
+            delete response;
             response = new MsgpackAsyncJsonResponse(false, 256);
-            response->setCode(507);
+            response->setCode(507); // Insufficient Storage
             response->setLength();
-            request->send(response); // Insufficient Storage (507)
+            request->send(response);
             return;
         }
         for (const auto & emsdevice : EMSESP::emsdevices) {


### PR DESCRIPTION
Not sure if it is really needed, the message buffer is NULL in this case, but it's cleaner to delete first response before creating a small new one. 
The http:507 (Insufficient Storage) does not show error.text only codenumber. Should we use 503 (Service Unavailable) instead?