### PR TITLE
burner settings use min/max from telegram 4, fix max for values < 0

### DIFF
--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -713,6 +713,17 @@ bool EMSdevice::has_command(const void * value_p) const {
     return false;
 }
 
+// set min and max
+void EMSdevice::set_minmax(const void * value_p, int16_t min, uint32_t max) {
+    for (auto & dv : devicevalues_) {
+        if (dv.value_p == value_p) {
+            dv.min = min;
+            dv.max = max;
+            return;
+        }
+    }
+}
+
 // publish a single value on change
 void EMSdevice::publish_value(void * value_p) const {
     if (!Mqtt::publish_single() || value_p == nullptr) {
@@ -1671,7 +1682,7 @@ bool EMSdevice::generate_values(JsonObject & output, const uint8_t tag_filter, c
                     if (v < dv.min) {
                         dv.min = v;
                         dv.remove_state(DeviceValueState::DV_HA_CONFIG_CREATED);
-                    } else if ((uint32_t)v > dv.max) {
+                    } else if (v > 0 && (uint32_t)v > dv.max) {
                         dv.max = v;
                         dv.remove_state(DeviceValueState::DV_HA_CONFIG_CREATED);
                     }

--- a/src/emsdevice.h
+++ b/src/emsdevice.h
@@ -303,6 +303,7 @@ class EMSdevice {
     bool is_readable(const void * value_p) const;
     bool is_readonly(const std::string & cmd, const int8_t id) const;
     bool has_command(const void * value_p) const;
+    void set_minmax(const void * value_p, int16_t min, uint32_t max);
     void publish_value(void * value_p) const;
     void publish_all_values();
 

--- a/src/emsdevicevalue.cpp
+++ b/src/emsdevicevalue.cpp
@@ -327,7 +327,7 @@ bool DeviceValue::get_custom_min(int16_t & val) {
     bool    has_min    = (min_pos != std::string::npos);
     uint8_t fahrenheit = !EMSESP::system_.fahrenheit() ? 0 : (uom == DeviceValueUOM::DEGREES) ? 2 : (uom == DeviceValueUOM::DEGREES_R) ? 1 : 0;
     if (has_min) {
-        uint32_t v = Helpers::atoint(custom_fullname.substr(min_pos + 1).c_str());
+        int16_t v = Helpers::atoint(custom_fullname.substr(min_pos + 1).c_str());
         if (fahrenheit) {
             v = (v - (32 * (fahrenheit - 1))) / 1.8; // reset to °C
         }
@@ -345,7 +345,7 @@ bool DeviceValue::get_custom_max(uint32_t & val) {
     bool    has_max    = (max_pos != std::string::npos);
     uint8_t fahrenheit = !EMSESP::system_.fahrenheit() ? 0 : (uom == DeviceValueUOM::DEGREES) ? 2 : (uom == DeviceValueUOM::DEGREES_R) ? 1 : 0;
     if (has_max) {
-        int v = Helpers::atoint(custom_fullname.substr(max_pos + 1).c_str());
+        int32_t v = Helpers::atoint(custom_fullname.substr(max_pos + 1).c_str());
         if (fahrenheit) {
             v = (v - (32 * (fahrenheit - 1))) / 1.8; // reset to °C
         }


### PR DESCRIPTION
This sets the min max limits of burner settings to the values read from telegram 4.