### PR TITLE
chore: fix typos of TLS

### DIFF
--- a/interface/src/framework/mqtt/MqttStatusForm.tsx
+++ b/interface/src/framework/mqtt/MqttStatusForm.tsx
@@ -69,7 +69,7 @@ const MqttStatusForm: FC = () => {
       case MqttDisconnectReason.MQTT_NOT_AUTHORIZED:
         return 'Not authorized';
       case MqttDisconnectReason.TLS_BAD_FINGERPRINT:
-        return 'TSL fingerprint invalid';
+        return 'TLS fingerprint invalid';
       default:
         return 'Unknown';
     }

--- a/interface/src/i18n/de/index.ts
+++ b/interface/src/i18n/de/index.ts
@@ -323,7 +323,7 @@ const de: Translation = {
   WRITEABLE: 'Schreibbar',
   SHOWING: 'Anzeigen von',
   SEARCH: 'Suche',
-  CERT: 'TSL Zertifikat (Freilassen um TSL zu deaktivieren)'
+  CERT: 'TLS Zertifikat (Freilassen um TLS zu deaktivieren)'
 };
 
 export default de;

--- a/interface/src/i18n/en/index.ts
+++ b/interface/src/i18n/en/index.ts
@@ -323,7 +323,7 @@ const en: Translation = {
   WRITEABLE: 'Writeable',
   SHOWING: 'Showing',
   SEARCH: 'Search',
-  CERT: 'TSL root certificate (leave blank to disable TSL)'
+  CERT: 'TLS root certificate (leave blank to disable TLS)'
 };
 
 export default en;

--- a/interface/src/i18n/fr/index.ts
+++ b/interface/src/i18n/fr/index.ts
@@ -323,7 +323,7 @@ const fr: Translation = {
   WRITEABLE: 'Writeable', // TODO translate
   SHOWING: 'Showing', // TODO translate
   SEARCH: 'Search', // TODO translate
-  CERT: 'TSL root certificate (leave blank to disable TSL)' // TODO translate
+  CERT: 'TLS root certificate (leave blank to disable TLS)' // TODO translate
 };
 
 export default fr;

--- a/interface/src/i18n/it/index.ts
+++ b/interface/src/i18n/it/index.ts
@@ -325,7 +325,7 @@ const it: Translation = {
   WRITEABLE: 'Scrivibile',
   SHOWING: 'Visualizza',
   SEARCH: 'Ricerca',
-  CERT: 'TSL root certificate (leave blank to disable TSL)' // TODO translate
+  CERT: 'TLS root certificate (leave blank to disable TLS)' // TODO translate
 };
 
 export default it;

--- a/interface/src/i18n/nl/index.ts
+++ b/interface/src/i18n/nl/index.ts
@@ -323,7 +323,7 @@ const nl: Translation = {
   WRITEABLE: 'Beschrijfbare',
   SHOWING: 'Tonen',
   SEARCH: 'Zoek',
-  CERT: 'TSL rootcertificaat (laat leeg om TSL uit te schakelen)'
+  CERT: 'TLS rootcertificaat (laat leeg om TLS uit te schakelen)'
 };
 
 export default nl;

--- a/interface/src/i18n/no/index.ts
+++ b/interface/src/i18n/no/index.ts
@@ -323,7 +323,7 @@ const no: Translation = {
   WRITEABLE: 'Writeable', // TODO translate
   SHOWING: 'Showing', // TODO translate
   SEARCH: 'Search', // TODO translate
-  CERT: 'TSL root certificate (leave blank to disable TSL)' // TODO translate
+  CERT: 'TLS root certificate (leave blank to disable TLS)' // TODO translate
 };
 
 export default no;

--- a/interface/src/i18n/pl/index.ts
+++ b/interface/src/i18n/pl/index.ts
@@ -323,7 +323,7 @@ const pl: BaseTranslation = {
   WRITEABLE: 'zapisywalna',
   SHOWING: 'Wyświetlane',
   SEARCH: 'Szukaj',
-  CERT: 'TSL root certificate (leave blank to disable TSL)' // TODO translate
+  CERT: 'TLS root certificate (leave blank to disable TLS)' // TODO translate
 };
 
 export default pl;

--- a/interface/src/i18n/sv/index.ts
+++ b/interface/src/i18n/sv/index.ts
@@ -323,7 +323,7 @@ const sv: Translation = {
   WRITEABLE: 'Writeable', // TODO translate
   SHOWING: 'Showing', // TODO translate
   SEARCH: 'Search', // TODO translate
-  CERT: 'TSL root certificate (leave blank to disable TSL)' // TODO translate
+  CERT: 'TLS root certificate (leave blank to disable TLS)' // TODO translate
 };
 
 export default sv;

--- a/interface/src/i18n/tr/index.ts
+++ b/interface/src/i18n/tr/index.ts
@@ -323,7 +323,7 @@ const tr: Translation = {
   WRITEABLE: 'Writeable', // TODO translate
   SHOWING: 'Showing', // TODO translate
   SEARCH: 'Search', // TODO translate
-  CERT: 'TSL root certificate (leave blank to disable TSL)' // TODO translate
+  CERT: 'TLS root certificate (leave blank to disable TLS)' // TODO translate
 };
 
 export default tr;


### PR DESCRIPTION
It looks like TLS has been incorrectly spelt TSL. Please correct me though if this is something different. 👍🏻