### PR TITLE
fix bug when traversing ems devices when using cmd allvalues

### DIFF
--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -817,7 +817,7 @@ std::string EMSdevice::get_value_uom(const std::string & shortname) const {
     return std::string{}; // not found
 }
 
-bool EMSdevice::export_values(uint8_t device_type, JsonObject & output, const int8_t id, const uint8_t output_target) {
+bool EMSdevice::export_values(uint8_t unique_id, JsonObject & output, const int8_t id, const uint8_t output_target) {
     bool    has_value = false;
     uint8_t tag;
     if (id >= 1 && id <= (1 + DeviceValueTAG::TAG_HS16 - DeviceValueTAG::TAG_HC1)) {
@@ -830,7 +830,7 @@ bool EMSdevice::export_values(uint8_t device_type, JsonObject & output, const in
 
     if (id > 0 || output_target == EMSdevice::OUTPUT_TARGET::API_VERBOSE) {
         for (const auto & emsdevice : EMSESP::emsdevices) {
-            if (emsdevice && (emsdevice->device_type() == device_type)) {
+            if (emsdevice->unique_id() == unique_id) {
                 has_value |= emsdevice->generate_values(output, tag, (id < 1), output_target); // use nested for id -1 and 0
             }
         }
@@ -842,7 +842,7 @@ bool EMSdevice::export_values(uint8_t device_type, JsonObject & output, const in
         JsonObject output_hc    = output;
         bool       nest_created = false;
         for (const auto & emsdevice : EMSESP::emsdevices) {
-            if (emsdevice && (emsdevice->device_type() == device_type)) {
+            if (emsdevice->unique_id() == unique_id) {
                 if (!nest_created && emsdevice->has_tags(tag)) {
                     output_hc    = output.createNestedObject(EMSdevice::tag_to_mqtt(tag));
                     nest_created = true;

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -112,14 +112,10 @@ bool System::command_allvalues(const char * value, const int8_t id, JsonObject &
     DynamicJsonDocument doc(EMSESP_JSON_SIZE_XXXLARGE);
     JsonObject          device_output;
 
-    for (const auto & device_class : EMSFactory::device_handlers()) {
-        for (const auto & emsdevice : EMSESP::emsdevices) {
-            if (emsdevice->device_type() == device_class.first) {
-                std::string title = emsdevice->device_type_2_device_name_translated() + std::string(" ") + emsdevice->to_string();
-                device_output     = output.createNestedObject(title);
-                emsesp::EMSdevice::export_values(emsdevice->device_type(), device_output, id, EMSdevice::OUTPUT_TARGET::API_VERBOSE);
-            }
-        }
+    for (const auto & emsdevice : EMSESP::emsdevices) {
+        std::string title = emsdevice->device_type_2_device_name_translated() + std::string(" ") + emsdevice->to_string();
+        device_output     = output.createNestedObject(title);
+        emsesp::EMSdevice::export_values(emsdevice->unique_id(), device_output, id, EMSdevice::OUTPUT_TARGET::API_VERBOSE);
     }
 
     // Custom entities

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -37,9 +37,8 @@ bool Test::run_test(const char * command, int8_t id) {
 
         // simulate HansRemmerswaal's setup - see https://github.com/emsesp/EMS-ESP32/issues/859
         add_device(0x08, 172); // 176 entities - boiler: Enviline/Compress 6000AW/Hybrid 3000-7000iAW/SupraEco/Geo 5xx/WLW196i
-
-        // add_device(0x10, 158); // 62 entities - thermostat: RC300/RC310/Moduline 3000/1010H/CW400/Sense II/HPC410
-        // add_device(0x38, 200); // 4 entities - thermostat: RC100H
+        add_device(0x10, 158); // 62 entities - thermostat: RC300/RC310/Moduline 3000/1010H/CW400/Sense II/HPC410
+        add_device(0x38, 200); // 4 entities - thermostat: RC100H
 
         return true;
     }
@@ -47,8 +46,12 @@ bool Test::run_test(const char * command, int8_t id) {
     if (strcmp(command, "general") == 0) {
         EMSESP::logger().info("Testing general. Adding a Boiler and Thermostat");
 
+        // System::test_set_all_active(true); // uncomment if we want to show all entities and give them fake values
+
         add_device(0x08, 123); // Nefit Trendline
         add_device(0x18, 157); // Bosch CR100
+
+        // add_device(0x10, 158); // RC300 - there's no data here
 
         // add some data
         // Boiler -> Me, UBAMonitorFast(0x18), telegram: 08 00 18 00 00 02 5A 73 3D 0A 10 65 40 02 1A 80 00 01 E1 01 76 0E 3D 48 00 C9 44 02 00 (#data=25)


### PR DESCRIPTION
use emsdevice->uniqueid for displaying values instead of searching the factory for registered types. when displaying more than 1 thermostat it got messed up