### PR TITLE
fix: Fixed dev section in analog sensor HA discovery

### DIFF
--- a/src/analogsensor.cpp
+++ b/src/analogsensor.cpp
@@ -116,7 +116,7 @@ void AnalogSensor::reload() {
             }
             if (!found) {
                 sensors_.emplace_back(sensor.gpio, sensor.name, sensor.offset, sensor.factor, sensor.uom, sensor.type);
-                sensors_.back().ha_registered = false; // this will trigger recrate of the HA config
+                sensors_.back().ha_registered = false; // this will trigger recreate of the HA config
                 if (sensor.type == AnalogType::COUNTER || sensor.type >= AnalogType::DIGITAL_OUT) {
                     sensors_.back().set_value(sensor.offset);
                 } else {
@@ -616,9 +616,9 @@ void AnalogSensor::publish_values(const bool force) {
                 }
 
                 JsonObject dev = config.createNestedObject("dev");
-                dev["name"]    = name;
+                dev["name"]    = Mqtt::basename() + " Analog";
                 JsonArray ids  = dev.createNestedArray("ids");
-                ids.add(Mqtt::basename());
+                ids.add(Mqtt::basename() + "-analog");
 
                 // add "availability" section
                 Mqtt::add_avty_to_doc(stat_t, config.as<JsonObject>(), val_cond);


### PR DESCRIPTION
Fixing #1516 filled by me a few minutes ago. This commit changes generating dev section similiar to mixer or boiler entities - dev name is "ems-esp-analog" and name is "ems-esp Analog". All entities from analog sensors shows in HA with this prefix by default.
 