### PR TITLE
Add Buderus MX300 Internet Gateway

### DIFF
--- a/src/device_library.h
+++ b/src/device_library.h
@@ -179,6 +179,7 @@
 
 // Gateways - 0x48
 {189, DeviceType::GATEWAY, "KM200/MB LAN 2", DeviceFlags::EMS_DEVICE_FLAG_NONE},
+{252, DeviceType::GATEWAY, "MX300", DeviceFlags::EMS_DEVICE_FLAG_NONE},
 
 // Generic - 0x40 or other with no product-id and no version
 {0, DeviceType::GENERIC, "unknown", DeviceFlags::EMS_DEVICE_FLAG_NONE}


### PR DESCRIPTION
This is Buderus MX300 Internet Gateway.

```
{
      "type": "gateway",
      "name": "WiFi module",
      "device id": "0x48",
      "product id": 252,
      "version": "07.02",
      "entities": 0,
      "handlers ignored": "0x2040"
    }
```

No fancy functionality yet but at least it is named then.


Doc PR: https://github.com/emsesp/docs/pull/32
