### PR TITLE
Fix Slovenian -> Slovak

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -10,7 +10,7 @@
 - heatpump energy meters [#1463](https://github.com/emsesp/EMS-ESP32/issues/1463)
 - heatpump max power [#1475](https://github.com/emsesp/EMS-ESP32/issues/1475)
 - checkbox for MQTT-TLS enable [#1474](https://github.com/emsesp/EMS-ESP32/issues/1474)
-- added SK (Slovenian) language. Thanks @misa1515
+- added SK (Slovak) language. Thanks @misa1515
 - CPU info [#1497](https://github.com/emsesp/EMS-ESP32/pull/1497)
 - Show network hostname in Web UI under Network Status
 - Improved HA Discovery so each section (EMS device, Scheduler, Analog, Temperature, Custom, Shower) have their own section


### PR DESCRIPTION
Newly added sk i18n file is in Slovak language
https://github.com/emsesp/EMS-ESP32/blob/dev/interface/src/i18n/sk/index.ts

Slovenia is not Slovakia, even though it is a [common](https://spectator.sme.sk/c/20025060/us-confusion-over-slovakia.html) [mistake](https://www.bbc.com/news/world-europe-43419675).

