### PR TITLE
Add Boiler Pump Characteristic for Bosch Condens 8300iW

### DIFF
--- a/mock-api/rest_server.ts
+++ b/mock-api/rest_server.ts
@@ -1417,6 +1417,13 @@ const emsesp_devicedata_3 = {
       l: ['proportional', 'deltaP-1', 'deltaP-2', 'deltaP-3', 'deltaP-4']
     },
     {
+      v: 'pressure3',
+      u: 0,
+      id: '00boiler pump characteristic',
+      c: 'pumpcharacter',
+      l: ['proportional', 'pressure1', 'pressure2', 'pressure3', 'pressure4', 'pressure5', 'pressure6']
+    },
+    {
       v: 6,
       u: 8,
       id: '00pump delay',

--- a/src/devices/boiler.cpp
+++ b/src/devices/boiler.cpp
@@ -275,6 +275,8 @@ Boiler::Boiler(uint8_t device_type, int8_t device_id, uint8_t product_id, const 
     register_device_value(
         DeviceValueTAG::TAG_DEVICE_DATA, &pumpMode_, DeviceValueType::ENUM, FL_(enum_pumpMode), FL_(pumpMode), DeviceValueUOM::NONE, MAKE_CF_CB(set_pumpMode));
     register_device_value(
+        DeviceValueTAG::TAG_DEVICE_DATA, &pumpCharacter_, DeviceValueType::ENUM, FL_(enum_pumpCharacter), FL_(pumpCharacter), DeviceValueUOM::NONE, MAKE_CF_CB(set_pumpCharacter));
+    register_device_value(
         DeviceValueTAG::TAG_DEVICE_DATA, &pumpDelay_, DeviceValueType::UINT8, FL_(pumpDelay), DeviceValueUOM::MINUTES, MAKE_CF_CB(set_pump_delay), 0, 60);
     register_device_value(DeviceValueTAG::TAG_DEVICE_DATA, &setFlowTemp_, DeviceValueType::UINT8, FL_(setFlowTemp), DeviceValueUOM::DEGREES);
     register_device_value(DeviceValueTAG::TAG_DEVICE_DATA, &setBurnPow_, DeviceValueType::UINT8, FL_(setBurnPow), DeviceValueUOM::PERCENT);
@@ -1397,7 +1399,7 @@ void Boiler::process_UBAMonitorFastPlus(std::shared_ptr<const Telegram> telegram
  * UBAMonitorSlow - type 0x19 - central heating monitor part 2 (27 bytes long)
  * received every 60 seconds
  * e.g. 08 00 19 00 80 00 02 41 80 00 00 00 00 00 03 91 7B 05 B8 40 00 00 00 04 92 AD 00 5E EE 80 00
- *      08 0B 19 00 FF EA 02 47 80 00 00 00 00 62 03 CA 24 2C D6 23 00 00 00 27 4A B6 03 6E 43 
+ *      08 0B 19 00 FF EA 02 47 80 00 00 00 00 62 03 CA 24 2C D6 23 00 00 00 27 4A B6 03 6E 43
  *                  00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 17 19 20 21 22 23 24
  */
 void Boiler::process_UBAMonitorSlow(std::shared_ptr<const Telegram> telegram) {
@@ -1478,8 +1480,9 @@ void Boiler::process_UBAParametersPlus(std::shared_ptr<const Telegram> telegram)
 
     // has_update(telegram, pumpType_, 11);   // guess, RC300 manual: power controlled, pressure controlled 1-4?
     // has_update(telegram, pumpDelay_, 12);  // guess
-    // has_update(telegram, pumpModMax_, 13); // guess
-    // has_update(telegram, pumpModMin_, 14); // guess
+    has_update(telegram, pumpModMax_, 13);
+    has_update(telegram, pumpModMin_, 14);
+    has_update(telegram, pumpCharacter_, 15);
 }
 
 // 0xEA
@@ -2417,6 +2420,15 @@ bool Boiler::set_pumpMode(const char * value, const int8_t id) {
     uint8_t v;
     if (Helpers::value2enum(value, v, FL_(enum_pumpMode))) {
         write_command(EMS_TYPE_UBAParameters, 11, v, EMS_TYPE_UBAParameters);
+        return true;
+    }
+    return false;
+}
+
+bool Boiler::set_pumpCharacter(const char * value, const int8_t id) {
+    uint8_t v;
+    if (Helpers::value2enum(value, v, FL_(enum_pumpCharacter))) {
+        write_command(EMS_TYPE_UBAParametersPlus, 15, v, EMS_TYPE_UBAParametersPlus);
         return true;
     }
     return false;

--- a/src/devices/boiler.h
+++ b/src/devices/boiler.h
@@ -130,6 +130,7 @@ class Boiler : public EMSdevice {
     uint8_t  pumpModMax_;       // Boiler circuit pump modulation max. power %
     uint8_t  pumpModMin_;       // Boiler circuit pump modulation min. power
     uint8_t  pumpMode_;         // pump setting proportional/deltaP
+    uint8_t  pumpCharacter_;    // pump setting proportional/deltaP
     uint8_t  pumpDelay_;
     uint8_t  burnMinPeriod_;
     uint8_t  burnMinPower_;
@@ -409,6 +410,7 @@ class Boiler : public EMSdevice {
     bool        set_min_pump(const char * value, const int8_t id);
     bool        set_max_pump(const char * value, const int8_t id);
     bool        set_pumpMode(const char * value, const int8_t id);
+    bool        set_pumpCharacter(const char * value, const int8_t id);
     bool        set_hyst_on(const char * value, const int8_t id);
     bool        set_hyst_off(const char * value, const int8_t id);
     inline bool set_hyst2_on(const char * value, const int8_t id) {

--- a/src/locale_common.h
+++ b/src/locale_common.h
@@ -1,7 +1,7 @@
 /*
  * EMS-ESP - https://github.com/emsesp/EMS-ESP
  * Copyright 2020-2024  Paul Derbyshire
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -288,6 +288,7 @@ MAKE_ENUM(enum_flow, FL_(off), FL_(flow), FL_(bufferedflow), FL_(buffer), FL_(la
 MAKE_ENUM(enum_reset, FL_(dash), FL_(maintenance), FL_(error), FL_(history), FL_(message))
 MAKE_ENUM(enum_maxHeat, FL_(0kW), FL_(2kW), FL_(3kW), FL_(4kW), FL_(6kW), FL_(9kW))
 MAKE_ENUM(enum_pumpMode, FL_(proportional), FL_(deltaP1), FL_(deltaP2), FL_(deltaP3), FL_(deltaP4))
+MAKE_ENUM(enum_pumpCharacter, FL_(proportional), FL_(pressure1), FL_(pressure2), FL_(pressure3), FL_(pressure4), FL_(pressure5), FL_(pressure6))
 MAKE_ENUM(enum_hpPumpMode, FL_(auto), FL_(continuous))
 
 // thermostat lists

--- a/src/locale_translations.h
+++ b/src/locale_translations.h
@@ -197,6 +197,12 @@ MAKE_WORD_TRANSLATION(deltaP1, "deltaP-1", "deltaP-1", "deltaP-1", "", "delta P-
 MAKE_WORD_TRANSLATION(deltaP2, "deltaP-2", "deltaP-2", "deltaP-2", "", "delta P-2", "deltaP-2", "", "deltaP-2", "deltaP-2", "deltaP-2") // TODO translate
 MAKE_WORD_TRANSLATION(deltaP3, "deltaP-3", "deltaP-3", "deltaP-3", "", "delta P-3", "deltaP-3", "", "deltaP-3", "deltaP-3", "deltaP-3") // TODO translate
 MAKE_WORD_TRANSLATION(deltaP4, "deltaP-4", "deltaP-4", "deltaP-4", "", "delta P-4", "deltaP-4", "", "deltaP-4", "deltaP-4", "deltaP-4") // TODO translate
+MAKE_WORD_TRANSLATION(pressure1, "150mbar", "150mbar", "150mbar", "150mbar", "150mbar", "150mbar", "150mbar", "150mbar", "150mbar", "150mbar") // TODO translate
+MAKE_WORD_TRANSLATION(pressure2, "200mbar", "200mbar", "200mbar", "200mbar", "200mbar", "200mbar", "200mbar", "200mbar", "200mbar", "200mbar") // TODO translate
+MAKE_WORD_TRANSLATION(pressure3, "250mbar", "250mbar", "250mbar", "250mbar", "250mbar", "250mbar", "250mbar", "250mbar", "250mbar", "250mbar") // TODO translate
+MAKE_WORD_TRANSLATION(pressure4, "300mbar", "300mbar", "300mbar", "300mbar", "300mbar", "300mbar", "300mbar", "300mbar", "300mbar", "300mbar") // TODO translate
+MAKE_WORD_TRANSLATION(pressure5, "350mbar", "350mbar", "350mbar", "350mbar", "350mbar", "350mbar", "350mbar", "350mbar", "350mbar", "350mbar") // TODO translate
+MAKE_WORD_TRANSLATION(pressure6, "400mbar", "400mbar", "400mbar", "400mbar", "400mbar", "400mbar", "400mbar", "400mbar", "400mbar", "400mbar") // TODO translate
 
 // heatpump
 MAKE_WORD_TRANSLATION(none, "none", "keine", "geen", "ingen", "brak", "ingen", "aucun", "hiçbiri", "nessuno", "žiadny")
@@ -349,6 +355,7 @@ MAKE_TRANSLATION(maintenanceTime, "maintenancetime", "time to next maintenance",
 MAKE_TRANSLATION(emergencyOps, "emergencyops", "emergency operation", "Notoperation", "Noodoperatie", "Nöddrift", "praca w trybie awaryjnym", "nøddrift", "opération d'urgence", "acil durum çalışması", "operazione di emergenza", "núdzová prevádzka")
 MAKE_TRANSLATION(emergencyTemp, "emergencytemp", "emergency temperature", "Nottemperatur", "Noodtemperatuur", "Nöddrift temperatur", "temperatura w trybie awaryjnym", "nødtemperatur", "température d'urgence", "acil durum sıcaklığı", "temperatura di emergenza", "núdzová teplota")
 MAKE_TRANSLATION(pumpMode, "pumpmode", "boiler pump mode", "Kesselpumpen Modus", "Ketelpomp modus", "", "tryb pracy pompy kotła", "pumpemodus", "", "pompa modu", "modalità pompa caldaia", "režim kotlového čerpadla") // TODO translate
+MAKE_TRANSLATION(pumpCharacter, "pumpcharacter", "boiler pump characteristic", "boiler pump characteristic", "boiler pump characteristic", "boiler pump characteristic", "boiler pump characteristic", "boiler pump characteristic", "boiler pump characteristic", "boiler pump characteristic", "boiler pump characteristic", "boiler pump characteristic") // TODO translate
 MAKE_TRANSLATION(headertemp, "headertemp", "low loss header", "Hydr. Weiche", "open verdeler", "", "sprzęgło hydrauliczne", "", "bouteille de déc. hydr.", "isı bloğu gidiş suyu sıc.", "comp. idr.", "nízkostratová hlavica") // TODO translate
 MAKE_TRANSLATION(heatblock, "heatblock", "heating block", "Wärmezelle", "Aanvoertemp. warmtecel", "", "blok grzewczy", "", "départ corps de chauffe", "Hid.denge kabı sıcaklığı", "mandata scamb. pr.", "vykurovací blok") // TODO translate
 
@@ -779,7 +786,7 @@ MAKE_TRANSLATION(pumpWorkTime, "pumpworktime", "pump working time", "Pumpenlaufz
 MAKE_TRANSLATION(pump2WorkTime, "pump2worktime", "pump 2 working time", "Pumpe 2 Laufzeit", "Looptijd pomp 2", "Pump 2 Drifttid", "czas pracy pompy 2", "driftstid pumpe2", "durée fonctionnement pompe 2", "pompa 2 çalışma süresi", "tempo funzionamento pompa 2", "pracovný čas čerpadla 2")
 MAKE_TRANSLATION(m1WorkTime, "m1worktime", "differential control working time", "Differenzregelung Arbeitszeit", "Verschilregeling arbeidstijd", "Differentialreglering Drifttid", "czas pracy regulacji różnicowej", "differentialreguleringssrifttid", "durée fonctionnement contrôle différentiel", "çalışma saatlerinin farklı düzenlenmesi", "controllo differenziale durata funzionamento", "pracovný čas diferenciálnej kontroly")
 MAKE_TRANSLATION(energyLastHour, "energylasthour", "energy last hour", "Energie letzte Std", "Energie laatste uur", "Energi Senaste Timmen", "energia w ciągu ostatniej godziny", "energi siste time", "énergie dernière heure", "son saat enerji", "Eenergia ultima ora", "energia za poslednú hodinu")
-MAKE_TRANSLATION(energyTotal, "energytotal", "total energy", "Gesamtenergie", "Totale energie", "Total Energi", "energia całkowita", "total energi", "énergie totale", "toplam enerji", "energia totale", "celková energia") 
+MAKE_TRANSLATION(energyTotal, "energytotal", "total energy", "Gesamtenergie", "Totale energie", "Total Energi", "energia całkowita", "total energi", "énergie totale", "toplam enerji", "energia totale", "celková energia")
 MAKE_TRANSLATION(energyToday, "energytoday", "total energy today", "Energie heute", "Energie vandaag", "Total Energi Idag", "energia całkowita dzisiaj", "total energi i dag", "énergie totale aujourd'hui", "bugün toplam enerji", "totale energia giornaliera", "celková energia dnes")
 
 // solar dhw


### PR DESCRIPTION
Hi all,

This PR to add Pump Characteristic control to the boiler I have. I need some assistance with it as I'm new to ESP development (not new to software development overall). When you can confirm that changes make sense I can build and test with my S3 board.

I have some uncertainty which I describe below and in inline comments. Thanks in advance for assistance!

## From manual
**Page 32** https://bosch-au-en-techdoc.boschtt-documents.com/index/td?query=7738101047&searchType=query&sales=in_sales&iframe=0&adminToken=0&art=0,all&brand=
**3-d1** Pump characteristic
• 0: Pump output proportional to the heat output
• 1: constant pressure 150 mbar
• 2: constant pressure 200 mbar
• 3: constant pressure 250 mbar
• 4: constant pressure 300 mbar
• 5: constant pressure 350 mbar
• 6: constant pressure 400 mbar

**3-d3** Min. output of the heating pump
• 10 ... 100 %
*Pump output at minimum heat output. Only available with pump characteristic 0.*

**3-d4** Max. output of the heating pump • 10 ... 100 % 
*Pump output at maximum heat output. Only available with pump characteristic 0.*


**My note:** Looks like comment `Only available with pump characteristic 0.` isn't fully correct as if I set max to 40% and characteristic to `6` pump is running on 40% only.


## Logs samples
**Setting 3-d1 to 0 (offset 15) (HEX logs)**
```
2024-06-10 10:36:59.396 TRACE 6442: [telegram] Rx: 89 08 E6 0F 00 B5
2024-06-10 10:36:59.437 TRACE 6443: [telegram] Rx: 88 00 F7 00 E6 00 00 3B FF 74 87 21 F4
2024-06-10 10:36:59.608 TRACE 6444: [telegram] Rx: 88 00 E6 0F 00 E5
```

**Setting 3-d1 to 2 (offset 15) (non-HEX logs)**
```
2024-06-10 10:31:24.016 TRACE 5871: [emsesp] controller(0x09) -W-> boiler(0x08), UBAParametersPlus(0xE6), data: 02 (offset 15)
2024-06-10 10:31:24.230 TRACE 5873: [emsesp] boiler(0x08) -B-> All(0x00), UBAParametersPlus(0xE6), data: 02 (offset 15)
```

**Report on reading all UBAParametersPlus**
```
2024-06-10 10:29:02.255 TRACE 5518: [emsesp] Me(0x0B) -R-> boiler(0x08), UBAParametersPlus(0xE6), length: 0x1B
2024-06-10 10:29:02.296 TRACE 5519: [emsesp] boiler(0x08) -W-> Me(0x0B), UBAParametersPlus(0xE6), data: 01 32 00 58 50 0C 00 00 06 FC 05 01 14 4B 19 00 00 00 00 1E 01 00 00 00 01 00 00
2024-06-10 10:29:02.509 TRACE 5521: [emsesp] boiler(0x08) -B-> All(0x00), UBAMonitorWWPlus(0xE9), data: 3C 02 5C 00 00 80 00 02 5C 46 00 15 11 22 00 B0 F7 00 8C B1 00 80 00 3C 01 00
2024-06-10 10:29:02.856 TRACE 5523: [emsesp] boiler(0x08) -B-> All(0x00), UBAMonitorSlowPlus(0xE5), data: 20 (offset 25)
2024-06-10 10:29:03.059 TRACE 5524: [emsesp] boiler(0x08) -B-> All(0x00), UBAMonitorSlowPlus(0xE5), data: 21 (offset 25)
2024-06-10 10:29:03.196 TRACE 5525: [emsesp] boiler(0x08) -B-> All(0x00), UBAMonitorSlowPlus(0xE5), data: 1F (offset 25)
2024-06-10 10:29:03.582 TRACE 5527: [emsesp] boiler(0x08) -B-> All(0x00), UBAMonitorSlowPlus(0xE5), data: 20 (offset 25)
2024-06-10 10:29:03.753 TRACE 5528: [emsesp] boiler(0x08) -B-> All(0x00), UBAMonitorSlowPlus(0xE5), data: 1F (offset 25)
2024-06-10 10:29:03.980 TRACE 5529: [emsesp] Me(0x0B) -R-> boiler(0x08), UBAParametersPlus(0xE6), length: 0x1B (offset 27)
2024-06-10 10:29:03.997 TRACE 5530: [emsesp] boiler(0x08) -W-> Me(0x0B), UBAParametersPlus(0xE6), data: 00 08 0D 78 00 00 00 00 00 (offset 30)
```

**Setting 3-d3 to 41 (offset 14) (HEX log)**
```
2024-06-10 10:37:54.837 TRACE 6556: [telegram] Rx: 89 08 E6 0E 29 9E
2024-06-10 10:37:54.908 TRACE 6557: [telegram] Rx: 88 00 E6 0D 4B 29 64
```

**Setting 3-d3 to 29 (offset 14) (non-HEX log)**
```
2024-06-10 10:34:33.801 TRACE 6164: [emsesp] controller(0x09) -W-> boiler(0x08), UBAParametersPlus(0xE6), data: 1D (offset 14)
2024-06-10 10:34:33.835 TRACE 6165: [emsesp] boiler(0x08) -B-> All(0x00), UBAParametersPlus(0xE6), data: 4B 1D (offset 13)
```
**Note and question:** Boiler replies with confirmation on offset 13, would it be  problem for parsing? (Works well for custom entities)

**Setting 3-d4 to 29 (offset 13) (HEX log)**
```
2024-06-10 10:38:44.551 TRACE 6602: [telegram] Rx: 89 08 E6 0D 49 F8
2024-06-10 10:38:44.585 TRACE 6603: [telegram] Rx: 88 00 E6 0D 49 29 60
```

## Custom user defined entities
I tested the following custom entities on my S3 board, they work fine (json):
```
{
  "type": "entities",
  "Entities": {
    "entities": [
      {
        "id": 0,
        "ram": 0,
        "device_id": 8,
        "type_id": 230,
        "offset": 15,
        "factor": 1,
        "name": "pumpcharacter",
        "uom": 0,
        "value_type": 2,
        "writeable": true
      },
      {
        "id": 1,
        "ram": 0,
        "device_id": 8,
        "type_id": 230,
        "offset": 13,
        "factor": 1,
        "name": "pumpmaxoutput",
        "uom": 3,
        "value_type": 2,
        "writeable": true
      },
      {
        "id": 2,
        "ram": 0,
        "device_id": 8,
        "type_id": 230,
        "offset": 14,
        "factor": 1,
        "name": "pumpminoutput",
        "uom": 3,
        "value_type": 2,
        "writeable": true
      }
    ]
  }
}
```

## System status
```
EMS-ESP Version

3.6.5
System Uptime

014+13:10:20.932
SDK

ESP32 Arduino v2.0.14 / ESP-IDF v4.4.6-dirty
CPU

ESP32-S3/ESP32-S3 (rev.0, dual-core) @ 240 Mhz
Heap (Free / Max Alloc)

194 KB / 175 KB
PSRAM (Size / Free)

8,189 KB / 8,161 KB
Flash Chip (Size / Speed)

16,384 KB / 80 MHz
Application (Partition: Used / Free)

app1: 2,139 KB / 5,989 KB
File System (Used / Free)

24 KB / 40 KB
```