### PR TITLE
add model() for CR120 for different modes

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -20,7 +20,7 @@
 - holiday settings for rego 3000  [#1735](https://github.com/emsesp/EMS-ESP32/issues/1735)
 - Added scripts for OTA (scripts/upload.py and upload_cli.py) [#1738](https://github.com/emsesp/EMS-ESP32/issues/1738)
 - timeout for remote thermostat emulation [#1680](https://github.com/emsesp/EMS-ESP32/discussions/1680), [#1774](https://github.com/emsesp/EMS-ESP32/issues/1774)
-- seltemp/mode for CR120 [#1779](https://github.com/emsesp/EMS-ESP32/discussions/1779)
+- CR120 thermostat as own model() [#1779](https://github.com/emsesp/EMS-ESP32/discussions/1779)
 - Modules - external linkable module library [#1778](https://github.com/emsesp/EMS-ESP32/issues/1778)
 
 ## Fixed

--- a/src/devices/thermostat.h
+++ b/src/devices/thermostat.h
@@ -220,7 +220,8 @@ class Thermostat : public EMSdevice {
 
     // check to see if the thermostat is a hybrid of the R300
     inline bool isRC300() const {
-        return ((model() == EMSdevice::EMS_DEVICE_FLAG_RC300) || (model() == EMSdevice::EMS_DEVICE_FLAG_R3000) || (model() == EMSdevice::EMS_DEVICE_FLAG_BC400));
+        return ((model() == EMSdevice::EMS_DEVICE_FLAG_RC300) || (model() == EMSdevice::EMS_DEVICE_FLAG_R3000) || (model() == EMSdevice::EMS_DEVICE_FLAG_BC400)
+                || (model() == EMSdevice::EMS_DEVICE_FLAG_CR120));
     }
 
     inline uint8_t id2dhw(const int8_t id) const {

--- a/src/emsdevice.h
+++ b/src/emsdevice.h
@@ -441,6 +441,7 @@ class EMSdevice {
     static constexpr uint8_t EMS_DEVICE_FLAG_RC100H      = 13; // with humidity
     static constexpr uint8_t EMS_DEVICE_FLAG_BC400       = 14; // mostly like RC300, but some changes
     static constexpr uint8_t EMS_DEVICE_FLAG_R3000       = 15; // Rego3000, same as RC300 with different wwmodes
+    static constexpr uint8_t EMS_DEVICE_FLAG_CR120       = 16; // mostly like RC300, but some changes
 
     uint8_t count_entities();
     bool    has_entities() const;

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -1232,7 +1232,11 @@ bool EMSESP::add_device(const uint8_t device_id, const uint8_t product_id, const
     if (device_id >= EMSdevice::EMS_DEVICE_ID_DHW1 && device_id <= EMSdevice::EMS_DEVICE_ID_DHW8) {
         device_type = DeviceType::WATER;
     }
-
+    // CR120 have version 22.xx, RC400/CW100 uses version 42.xx, see https://github.com/emsesp/EMS-ESP32/discussions/1779
+    if (product_id == 157 && version[0] == '2') {
+        flags = DeviceFlags::EMS_DEVICE_FLAG_CR120;
+        name  = "CR120";
+    }
     // empty reply to version, read a generic device from database
     if (product_id == 0) {
         // check for known device IDs

--- a/src/locale_common.h
+++ b/src/locale_common.h
@@ -304,6 +304,7 @@ MAKE_ENUM(enum_wwMode2, FL_(off), FL_(on), FL_(auto))
 MAKE_ENUM(enum_wwMode3, FL_(on), FL_(off), FL_(auto))
 MAKE_ENUM(enum_wwMode4, FL_(off), FL_(ecoplus), FL_(eco), FL_(comfort), FL_(auto))
 MAKE_ENUM(enum_wwMode5, FL_(normal), FL_(comfort), FL_(ecoplus)) // Rego3000
+MAKE_ENUM(enum_wwMode6, FL_(normal), FL_(comfort), FL_(auto)) // CR120
 MAKE_ENUM(enum_heatingtype, FL_(off), FL_(radiator), FL_(convector), FL_(floor))
 MAKE_ENUM(enum_heatingtype1, FL_(off), FL_(curve), FL_(radiator), FL_(convector), FL_(floor))
 MAKE_ENUM(enum_summermode, FL_(summer), FL_(auto), FL_(winter))

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define EMSESP_APP_VERSION "3.7.0-dev.13"
+#define EMSESP_APP_VERSION "3.7.0-dev.14"


### PR DESCRIPTION
This is now the EMS_DEVICE_FLAG_CR120.
No need for checking and comparing different offsets in Set-telegram, BC400 and CR120 take offset21 as mode, the others offset 0.
Maybe dhw mode is not correct, but easy to adapt now.