### PR TITLE
minor changes

### DIFF
--- a/.github/workflows/sonar_check.yml
+++ b/.github/workflows/sonar_check.yml
@@ -5,8 +5,8 @@ on:
   push:
     branches:
       - dev
-  pull_request:
-    types: [opened, synchronize, reopened]
+  # pull_request:
+  #   types: [opened, synchronize, reopened]
 
 jobs:
   build:

--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -5,7 +5,7 @@
 ## **IMPORTANT! BREAKING CHANGES**
 
 - new device WATER shows dhw entities from MM100 and SM100 in dhw setting
-- rename WWC to DHW, always create DHW nests/topics, remove ww prefix from mqtt names [#1634](https://github.com/emsesp/EMS-ESP32/issues/1634)
+- renamed WWC to DHW, always create DHW nests/topics, remove ww prefix from mqtt names [#1634](https://github.com/emsesp/EMS-ESP32/issues/1634)
 
 ## Added
 
@@ -40,3 +40,4 @@
 - dynamic register dhw circuits for thermostat
 - removed OTA feature [#1738](https://github.com/emsesp/EMS-ESP32/issues/1738)
 - added shower min duration [[#1801](https://github.com/emsesp/EMS-ESP32/issues/1801)]
+- Include TXT file along with the generated CSV for Device Data export/download

--- a/interface/src/i18n/en/index.ts
+++ b/interface/src/i18n/en/index.ts
@@ -23,7 +23,7 @@ const en: Translation = {
   ONOFF: 'on/off',
   TYPE: 'Type',
   DESCRIPTION: 'Description',
-  ENTITIES: 'Entities',
+  ENTITIES: 'entities',
   REFRESH: 'Refresh',
   EXPORT: 'Export',
   DEVICE_DETAILS: 'Device Details',

--- a/interface/src/i18n/fr/index.ts
+++ b/interface/src/i18n/fr/index.ts
@@ -23,7 +23,7 @@ const fr: Translation = {
   ONOFF: 'on/off',
   TYPE: 'Type',
   DESCRIPTION: 'Description',
-  ENTITIES: 'Entités',
+  ENTITIES: 'entités',
   REFRESH: 'Rafraîchir',
   EXPORT: 'Exporter',
   DEVICE_DETAILS: "Détails de l'appareil",

--- a/interface/src/i18n/it/index.ts
+++ b/interface/src/i18n/it/index.ts
@@ -23,7 +23,7 @@ const it: Translation = {
   ONOFF: 'on/off',
   TYPE: 'Tipo',
   DESCRIPTION: 'Descrizione',
-  ENTITIES: 'Entità',
+  ENTITIES: 'entità',
   REFRESH: 'Ricaricare',
   EXPORT: 'Esporta',
   DEVICE_DETAILS: 'Dettagli dispositivo',

--- a/interface/src/i18n/nl/index.ts
+++ b/interface/src/i18n/nl/index.ts
@@ -23,7 +23,7 @@ const nl: Translation = {
   ONOFF: 'aan/uit',
   TYPE: 'Type',
   DESCRIPTION: 'Beschrijving',
-  ENTITIES: 'Entiteiten',
+  ENTITIES: 'entiteiten',
   REFRESH: 'Ververs',
   EXPORT: 'Export',
   DEVICE_DETAILS: 'Device Gegevens',

--- a/interface/src/i18n/sk/index.ts
+++ b/interface/src/i18n/sk/index.ts
@@ -23,7 +23,7 @@ const sk: Translation = {
   ONOFF: 'zap/vyp',
   TYPE: 'Typ',
   DESCRIPTION: 'Popis',
-  ENTITIES: 'Entity',
+  ENTITIES: 'entity',
   REFRESH: 'Obnoviť',
   EXPORT: 'Export',
   DEVICE_DETAILS: 'Detaily zariadenia',

--- a/interface/src/i18n/sv/index.ts
+++ b/interface/src/i18n/sv/index.ts
@@ -23,7 +23,7 @@ const sv: Translation = {
   ONOFF: 'på/av',
   TYPE: 'Typ',
   DESCRIPTION: 'Beskrivning',
-  ENTITIES: 'Entiteter',
+  ENTITIES: 'entiteter',
   REFRESH: 'Uppdatera',
   EXPORT: 'Exportera',
   DEVICE_DETAILS: 'Enhetsdetaljer',

--- a/interface/src/i18n/tr/index.ts
+++ b/interface/src/i18n/tr/index.ts
@@ -23,7 +23,7 @@ const tr: Translation = {
   ONOFF: 'açık/kapalı',
   TYPE: 'Tür',
   DESCRIPTION: 'Açıklama',
-  ENTITIES: 'Varlıklar',
+  ENTITIES: 'varlıklar',
   REFRESH: 'Yenile',
   EXPORT: 'Dışarı al',
   DEVICE_DETAILS: 'Cihaz Ayrıntıları',

--- a/interface/src/project/Devices.tsx
+++ b/interface/src/project/Devices.tsx
@@ -426,8 +426,9 @@ const Devices: FC = () => {
       document.body.removeChild(downloadLink);
     };
 
+    const device = { ...{ device: coreData.devices[deviceIndex] }, ...deviceData };
     downloadBlob(
-      new Blob([JSON.stringify(deviceData, null, 2)], {
+      new Blob([JSON.stringify(device, null, 2)], {
         type: 'text;charset:utf-8'
       })
     );
@@ -650,7 +651,7 @@ const Devices: FC = () => {
           </Typography>
 
           <Grid container justifyContent="space-between">
-            <Typography sx={{ ml: 1 }} variant="subtitle2" color="primary">
+            <Typography sx={{ ml: 1 }} variant="subtitle2" color="grey">
               {LL.SHOWING() +
                 ' ' +
                 shown_data.length +
@@ -660,61 +661,40 @@ const Devices: FC = () => {
                 LL.ENTITIES(shown_data.length)}
               <ButtonTooltip title="Info">
                 <IconButton onClick={() => setShowDeviceInfo(true)}>
-                  <InfoOutlinedIcon
-                    color="primary"
-                    sx={{ fontSize: 18, verticalAlign: 'middle' }}
-                  />
+                  <InfoOutlinedIcon color="primary" sx={{ fontSize: 18 }} />
                 </IconButton>
               </ButtonTooltip>
               {me.admin && (
                 <ButtonTooltip title={LL.CUSTOMIZATIONS()}>
                   <IconButton onClick={customize}>
-                    <FormatListNumberedIcon
-                      color="primary"
-                      sx={{ fontSize: 18, verticalAlign: 'middle' }}
-                    />
+                    <FormatListNumberedIcon color="primary" sx={{ fontSize: 18 }} />
                   </IconButton>
                 </ButtonTooltip>
               )}
               <ButtonTooltip title={LL.EXPORT()}>
                 <IconButton onClick={handleDownloadCsv}>
-                  <DownloadIcon
-                    color="primary"
-                    sx={{ fontSize: 18, verticalAlign: 'middle' }}
-                  />
+                  <DownloadIcon color="primary" sx={{ fontSize: 18 }} />
                 </IconButton>
               </ButtonTooltip>
               <ButtonTooltip title="Favorites">
                 <IconButton onClick={() => setOnlyFav(!onlyFav)}>
                   {onlyFav ? (
-                    <StarIcon
-                      color="primary"
-                      sx={{ fontSize: 18, verticalAlign: 'middle' }}
-                    />
+                    <StarIcon color="primary" sx={{ fontSize: 18 }} />
                   ) : (
-                    <StarBorderOutlinedIcon
-                      color="primary"
-                      sx={{ fontSize: 18, verticalAlign: 'middle' }}
-                    />
+                    <StarBorderOutlinedIcon color="primary" sx={{ fontSize: 18 }} />
                   )}
                 </IconButton>
               </ButtonTooltip>
               <ButtonTooltip title={LL.REFRESH()}>
                 <IconButton onClick={refreshData}>
-                  <RefreshIcon
-                    color="primary"
-                    sx={{ fontSize: 18, verticalAlign: 'middle' }}
-                  />
+                  <RefreshIcon color="primary" sx={{ fontSize: 18 }} />
                 </IconButton>
               </ButtonTooltip>
             </Typography>
             <Grid item zeroMinWidth justifyContent="flex-end">
               <ButtonTooltip title={LL.CANCEL()}>
                 <IconButton onClick={resetDeviceSelect}>
-                  <HighlightOffIcon
-                    color="primary"
-                    sx={{ fontSize: 18, verticalAlign: 'middle' }}
-                  />
+                  <HighlightOffIcon color="primary" sx={{ fontSize: 18 }} />
                 </IconButton>
               </ButtonTooltip>
             </Grid>

--- a/lib/framework/ESP8266React.cpp
+++ b/lib/framework/ESP8266React.cpp
@@ -39,6 +39,7 @@ ESP8266React::ESP8266React(AsyncWebServer * server, FS * fs)
             response->addHeader("Content-Encoding", "gzip");
             // response->addHeader("Content-Encoding", "br"); // only works over HTTPS
             // response->addHeader("Cache-Control", "public, immutable, max-age=31536000");
+            response->addHeader("Cache-Control", "must-revalidate"); // ensure that a client will check the server for a change
             response->addHeader("Last-Modified", last_modified);
             response->addHeader("ETag", hash);
 
@@ -46,6 +47,7 @@ ESP8266React::ESP8266React(AsyncWebServer * server, FS * fs)
         };
 
         server->on(uri, HTTP_GET, requestHandler);
+
         // Serving non matching get requests with "/index.html"
         // OPTIONS get a straight up 200 response
         if (strncmp(uri, "/index.html", 11) == 0) {

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define EMSESP_APP_VERSION "3.7.0-dev.17"
+#define EMSESP_APP_VERSION "3.7.0-dev.18"


### PR DESCRIPTION
- device values export also includes the device data as well as the entities
- don't run Sonar on every pull, just push
- force client to verify cache - maybe this will help with people forgetting to Refresh/F5 browser after updates?