### PR TITLE
scheduler async, command use string, lowercase

### DIFF
--- a/src/command.cpp
+++ b/src/command.cpp
@@ -204,7 +204,7 @@ uint8_t Command::process(const char * path, const bool is_admin, const JsonObjec
     return return_code;
 }
 
-std::string Command::return_code_string(const uint8_t return_code) {
+const char * Command::return_code_string(const uint8_t return_code) {
     switch (return_code) {
     case CommandRet::ERROR:
         return "Error";
@@ -380,9 +380,9 @@ uint8_t Command::call(const uint8_t device_type, const char * cmd, const char * 
     if (return_code != CommandRet::OK) {
         char error[100];
         if (single_command) {
-            snprintf(error, sizeof(error), "Command '%s' failed (%s)", cmd, FL_(cmdRet)[return_code]);
+            snprintf(error, sizeof(error), "Command '%s' failed (%s)", cmd, return_code_string(return_code));
         } else {
-            snprintf(error, sizeof(error), "Command '%s: %s' failed (%s)", cmd, value, FL_(cmdRet)[return_code]);
+            snprintf(error, sizeof(error), "Command '%s: %s' failed (%s)", cmd, value, return_code_string(return_code));
         }
         output.clear();
         output["message"] = error;

--- a/src/command.h
+++ b/src/command.h
@@ -51,8 +51,6 @@ enum CommandRet : uint8_t {
     INVALID      // 5 - invalid (tag)
 };
 
-MAKE_ENUM_FIXED(cmdRet, "fail", "ok", "not found", "error", "not allowed", "invalid")
-
 using cmd_function_p      = std::function<bool(const char * data, const int8_t id)>;
 using cmd_json_function_p = std::function<bool(const char * data, const int8_t id, JsonObject output)>;
 
@@ -138,7 +136,7 @@ class Command {
 
     static const char * parse_command_string(const char * command, int8_t & id);
 
-    static std::string return_code_string(const uint8_t return_code);
+    static const char * return_code_string(const uint8_t return_code);
 
   private:
     static uuid::log::Logger logger_;

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -1719,7 +1719,6 @@ void EMSESP::loop() {
         analogsensor_.loop();       // read analog sensor values
         publish_all_loop();         // with HA messages in parts to avoid flooding the mqtt queue
         mqtt_.loop();               // sends out anything in the MQTT queue
-        webSchedulerService.loop(); // handle any scheduled jobs
         webModulesService.loop();   // loop through the external library modules
 
         // force a query on the EMS devices to fetch latest data at a set interval (1 min)

--- a/src/modbus.cpp
+++ b/src/modbus.cpp
@@ -440,9 +440,9 @@ ModbusMessage Modbus::handleWrite(const ModbusMessage & request) {
                      sizeof(error),
                      "Modbus write command failed with error: %s (%s)",
                      (const char *)output["message"],
-                     Command::return_code_string(return_code).c_str());
+                     Command::return_code_string(return_code));
         } else {
-            snprintf(error, sizeof(error), "Modbus write command failed with error code (%s)", Command::return_code_string(return_code).c_str());
+            snprintf(error, sizeof(error), "Modbus write command failed with error code (%s)", Command::return_code_string(return_code));
         }
         LOG_ERROR(error);
         response.setError(request.getServerID(), request.getFunctionCode(), ILLEGAL_DATA_VALUE);

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -285,13 +285,9 @@ void Mqtt::on_message(const char * topic, const uint8_t * payload, size_t len) {
     if (return_code != CommandRet::OK) {
         char error[100];
         if (output.size()) {
-            snprintf(error,
-                     sizeof(error),
-                     "MQTT command failed with error %s (%s)",
-                     (const char *)output["message"],
-                     Command::return_code_string(return_code).c_str());
+            snprintf(error, sizeof(error), "MQTT command failed with error %s (%s)", (const char *)output["message"], Command::return_code_string(return_code));
         } else {
-            snprintf(error, sizeof(error), "MQTT command failed with error %s", Command::return_code_string(return_code).c_str());
+            snprintf(error, sizeof(error), "MQTT command failed with error %s", Command::return_code_string(return_code));
         }
         LOG_ERROR(error);
         Mqtt::queue_publish("response", error);

--- a/src/web/WebDataService.cpp
+++ b/src/web/WebDataService.cpp
@@ -259,7 +259,7 @@ void WebDataService::write_device_value(AsyncWebServerRequest * request, JsonVar
 
                 // write debug
                 if (return_code != CommandRet::OK) {
-                    EMSESP::logger().err("Write command failed %s (%s)", (const char *)output["message"], Command::return_code_string(return_code).c_str());
+                    EMSESP::logger().err("Write command failed %s (%s)", (const char *)output["message"], Command::return_code_string(return_code));
                 } else {
 #if defined(EMSESP_DEBUG)
                     EMSESP::logger().debug("Write command successful");
@@ -292,7 +292,7 @@ void WebDataService::write_device_value(AsyncWebServerRequest * request, JsonVar
                 return_code = Command::call(device_type, cmd, Helpers::render_value(s, data.as<float>(), 1), true, id, output);
             }
             if (return_code != CommandRet::OK) {
-                EMSESP::logger().err("Write command failed %s (%s)", (const char *)output["message"], Command::return_code_string(return_code).c_str());
+                EMSESP::logger().err("Write command failed %s (%s)", (const char *)output["message"], Command::return_code_string(return_code));
             } else {
 #if defined(EMSESP_DEBUG)
                 EMSESP::logger().debug("Write command successful");

--- a/src/web/WebSchedulerService.h
+++ b/src/web/WebSchedulerService.h
@@ -73,7 +73,9 @@ class WebSchedulerService : public StatefulService<WebScheduler> {
 #ifndef EMSESP_STANDALONE
   private:
 #endif
-    bool command(const char * name, const char * cmd, const char * data);
+    static void scheduler_task(void * pvParameters);
+
+    bool command(const char * name, const std::string & cmd, const std::string & data);
     void condition();
 
     HttpEndpoint<WebScheduler>  _httpEndpoint;
@@ -81,6 +83,7 @@ class WebSchedulerService : public StatefulService<WebScheduler> {
 
     std::list<ScheduleItem> * scheduleItems_; // pointer to the list of schedule events
     bool                      ha_registered_ = false;
+    std::deque<std::string>   cmd_changed_;
 };
 
 } // namespace emsesp

--- a/src/web/shuntingYard.hpp
+++ b/src/web/shuntingYard.hpp
@@ -630,7 +630,6 @@ std::string compute(const std::string & expr) {
                 } else {
                     httpResult = http.GET(); // normal GET
                 }
-                http.end();
 
                 if (httpResult > 0) {
                     std::string result = emsesp::Helpers::toLower(http.getString().c_str());
@@ -641,6 +640,7 @@ std::string compute(const std::string & expr) {
                     }
                     expr_new.replace(f, e - f, result.c_str());
                 }
+                http.end();
             }
         }
         f = expr_new.find_first_of("{", e);

--- a/src/web/shuntingYard.hpp
+++ b/src/web/shuntingYard.hpp
@@ -622,18 +622,13 @@ std::string compute(const std::string & expr) {
                 String method = doc["method"] | "GET"; // default GET
 
                 // if there is data, force a POST
-                if (value.length()) {
+                if (value.length() || method == "post") {
                     if (value.startsWith("{")) {
                         http.addHeader("Content-Type", "application/json"); // auto-set to JSON
                     }
                     httpResult = http.POST(value);
                 } else {
-                    // no value, but check if it still a POST request
-                    if (method == "POST") {
-                        httpResult = http.POST(value);
-                    } else {
-                        httpResult = http.GET(); // normal GET
-                    }
+                    httpResult = http.GET(); // normal GET
                 }
                 http.end();
 


### PR DESCRIPTION
I've changed the command paramters to string, makes it easier to lowercase convert and saves a lot of .c_str()
For the command we don't need to check for '{' as first character, the deserialize parses good, accept also blanks before '{'

Please check.