### PR TITLE
schedule onChange optimize queue

### DIFF
--- a/src/web/WebSchedulerService.h
+++ b/src/web/WebSchedulerService.h
@@ -81,9 +81,9 @@ class WebSchedulerService : public StatefulService<WebScheduler> {
     HttpEndpoint<WebScheduler>  _httpEndpoint;
     FSPersistence<WebScheduler> _fsPersistence;
 
-    std::list<ScheduleItem> * scheduleItems_; // pointer to the list of schedule events
-    bool                      ha_registered_ = false;
-    std::deque<std::string>   cmd_changed_;
+    std::list<ScheduleItem> *  scheduleItems_; // pointer to the list of schedule events
+    bool                       ha_registered_ = false;
+    std::deque<ScheduleItem *> cmd_changed_;
 };
 
 } // namespace emsesp


### PR DESCRIPTION
The onChange is called very often, e.g.  a boiler 0x18 telegram can have tens of changes that each calls onChange and grows the queue. Better to filter only the relevant changes and queue only the effected schedules as pointer to the schedule data. 