### PR TITLE
upload and install firmware automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,9 +47,6 @@ interface/src/i18n/i18n-types.ts
 interface/src/i18n/i18n-util.ts
 interface/src/i18n/i18n-util.sync.ts
 interface/src/i18n/i18n-util.async.ts
-# mock-api uploads
-*/uploads/*
-!uploads/README.md
 
 # scripts
 test.sh

--- a/interface/package.json
+++ b/interface/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint . --fix"
   },
   "dependencies": {
-    "@alova/adapter-xhr": "2.0.4",
+    "@alova/adapter-xhr": "2.0.5",
     "@emotion/react": "^11.13.0",
     "@emotion/styled": "^11.13.0",
     "@mui/icons-material": "^5.16.7",

--- a/interface/src/api/system.ts
+++ b/interface/src/api/system.ts
@@ -45,3 +45,6 @@ export const uploadFile = (file: File) => {
     timeout: 60000 // override timeout for uploading firmware - 1 minute
   });
 };
+
+export const uploadURL = (data: { url: string }) =>
+  alovaInstance.Post('/rest/uploadURL', data);

--- a/interface/src/app/main/Help.tsx
+++ b/interface/src/app/main/Help.tsx
@@ -113,7 +113,7 @@ const Help = () => {
           color="primary"
           onClick={() => callAPI('system', 'allvalues')}
         >
-            {LL.ALLVALUES(0)}
+          {LL.ALLVALUES(0)}
         </Button>
 
         <Box border={1} p={1} mt={4}>

--- a/interface/src/app/main/Sensors.tsx
+++ b/interface/src/app/main/Sensors.tsx
@@ -59,15 +59,18 @@ const Sensors = () => {
   const [analogDialogOpen, setAnalogDialogOpen] = useState<boolean>(false);
   const [creating, setCreating] = useState<boolean>(false);
 
-  const { data: sensorData } = useAutoRequest(() => readSensorData(), {
-    initialData: {
-      ts: [],
-      as: [],
-      analog_enabled: false,
-      platform: 'ESP32'
-    },
-    pollingTime: 2000
-  });
+  const { data: sensorData, send: fetchSensorData } = useAutoRequest(
+    () => readSensorData(),
+    {
+      initialData: {
+        ts: [],
+        as: [],
+        analog_enabled: false,
+        platform: 'ESP32'
+      },
+      pollingTime: 2000
+    }
+  );
 
   const { send: sendTemperatureSensor } = useRequest(
     (data: WriteTemperatureSensor) => writeTemperatureSensor(data),
@@ -256,6 +259,7 @@ const Sensors = () => {
 
   const onTemperatureDialogClose = () => {
     setTemperatureDialogOpen(false);
+    void fetchSensorData();
   };
 
   const onTemperatureDialogSave = async (ts: TemperatureSensor) => {
@@ -269,6 +273,7 @@ const Sensors = () => {
       .finally(() => {
         setTemperatureDialogOpen(false);
         setSelectedTemperatureSensor(undefined);
+        void fetchSensorData();
       });
   };
 
@@ -283,6 +288,7 @@ const Sensors = () => {
 
   const onAnalogDialogClose = () => {
     setAnalogDialogOpen(false);
+    void fetchSensorData();
   };
 
   const addAnalogSensor = () => {
@@ -322,6 +328,7 @@ const Sensors = () => {
       .finally(() => {
         setAnalogDialogOpen(false);
         setSelectedAnalogSensor(undefined);
+        void fetchSensorData();
       });
   };
 

--- a/interface/src/app/settings/DownloadUpload.tsx
+++ b/interface/src/app/settings/DownloadUpload.tsx
@@ -97,18 +97,18 @@ const DownloadUpload = () => {
 
   // called immediately to get the latest version, on page load
   const { data: latestVersion } = useRequest(getStableVersion, {
-    // immediate: true
+    immediate: true
     // uncomment for testing
     // https://github.com/emsesp/EMS-ESP32/releases/download/v3.6.5/EMS-ESP-3_6_5-ESP32-16MB+.bin
-    immediate: false,
-    initialData: '3.6.5'
+    // immediate: false,
+    // initialData: '3.6.5'
   });
   const { data: latestDevVersion } = useRequest(getDevVersion, {
-    // immediate: true
+    immediate: true
     // uncomment for testing
     // https://github.com/emsesp/EMS-ESP32/releases/download/latest/EMS-ESP-3_7_0-dev_31-ESP32-16MB+.bin
-    immediate: false,
-    initialData: '3.7.0-dev.31'
+    // immediate: false,
+    // initialData: '3.7.0-dev.31'
   });
 
   const STABLE_URL = 'https://github.com/emsesp/EMS-ESP32/releases/download/';

--- a/interface/src/app/settings/DownloadUpload.tsx
+++ b/interface/src/app/settings/DownloadUpload.tsx
@@ -4,17 +4,7 @@ import { toast } from 'react-toastify';
 import DownloadIcon from '@mui/icons-material/GetApp';
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew';
 import WarningIcon from '@mui/icons-material/Warning';
-import {
-  Box,
-  Button,
-  CircularProgress,
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  Divider,
-  Link,
-  Typography
-} from '@mui/material';
+import { Box, Button, Divider, Link, Typography } from '@mui/material';
 
 import * as SystemApi from 'api/system';
 import {
@@ -44,7 +34,6 @@ const DownloadUpload = () => {
 
   const [restarting, setRestarting] = useState<boolean>(false);
   const [restartNeeded, setRestartNeeded] = useState<boolean>(false);
-  const [showWaiting, setShowWaiting] = useState<boolean>(false);
 
   const { send: sendSettings } = useRequest(getSettings(), {
     immediate: false
@@ -141,10 +130,10 @@ const DownloadUpload = () => {
   };
 
   const installFirmwareURL = async (url: string) => {
-    setShowWaiting(true);
     await sendUploadURL({ url: url }).catch((error: Error) => {
       toast.error(error.message);
     });
+    setRestarting(true);
   };
 
   const saveFile = (json: unknown, filename: string) => {
@@ -357,27 +346,6 @@ const DownloadUpload = () => {
           )}
         </Box>
 
-        <Dialog sx={dialogStyle} open={showWaiting}>
-          {/* TODO translate all this text*/}
-          <DialogTitle>Uploading</DialogTitle>
-          <DialogContent dividers>
-            <Typography sx={{ ml: 2, flexGrow: 1 }} color="warning.main">
-              Please wait while the firmware is being uploaded and installed. This
-              can take a few minutes. EMS-ESP will automatically restart when
-              completed.
-            </Typography>
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              flexDirection="column"
-              padding={2}
-            >
-              <CircularProgress sx={{ margin: 4 }} size={36} />
-            </Box>
-          </DialogContent>
-        </Dialog>
-
         <Typography sx={{ pt: 2, pb: 2 }} variant="h6" color="primary">
           {LL.UPLOAD()}
         </Typography>
@@ -405,7 +373,13 @@ const DownloadUpload = () => {
   };
 
   return (
-    <SectionContent>{restarting ? <RestartMonitor /> : content()}</SectionContent>
+    <SectionContent>
+      {restarting ? (
+        <RestartMonitor message="Please wait while the firmware is being uploaded and installed. This can take a few minutes. EMS-ESP will automatically restart when completed." />
+      ) : (
+        content()
+      )}
+    </SectionContent>
   );
 };
 

--- a/interface/src/app/status/RestartMonitor.tsx
+++ b/interface/src/app/status/RestartMonitor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 
 import * as SystemApi from 'api/system';
 
@@ -6,10 +6,14 @@ import { useRequest } from 'alova/client';
 import { FormLoader } from 'components';
 import { useI18nContext } from 'i18n/i18n-react';
 
-const RESTART_TIMEOUT = 2 * 60 * 1000;
-const POLL_INTERVAL = 1000;
+const RESTART_TIMEOUT = 2 * 60 * 1000; // 2 minutes
+const POLL_INTERVAL = 1000; // every 1 second
 
-const RestartMonitor = () => {
+export interface RestartMonitorProps {
+  message?: string;
+}
+
+const RestartMonitor: FC<RestartMonitorProps> = ({ message }) => {
   const [failed, setFailed] = useState<boolean>(false);
   const [timeoutId, setTimeoutId] = useState<NodeJS.Timeout>();
   const { LL } = useI18nContext();
@@ -38,7 +42,7 @@ const RestartMonitor = () => {
 
   return (
     <FormLoader
-      message={LL.APPLICATION_RESTARTING() + '...'}
+      message={message ? message : LL.APPLICATION_RESTARTING() + '...'}
       errorMessage={failed ? 'Timed out' : undefined}
     />
   );

--- a/interface/src/app/status/Status.tsx
+++ b/interface/src/app/status/Status.tsx
@@ -306,7 +306,7 @@ const SystemStatus = () => {
   );
 
   const content = () => {
-    if (!data) {
+    if (!data || !LL) {
       return <FormLoader onRetry={loadData} errorMessage={error?.message} />;
     }
 
@@ -321,7 +321,7 @@ const SystemStatus = () => {
             </ListItemAvatar>
             <ListItemText
               primary={LL.EMS_ESP_VER()}
-              secondary={data.emsesp_version}
+              secondary={'' + data.emsesp_version}
             />
             {me.admin && (
               <Button

--- a/interface/src/types/system.ts
+++ b/interface/src/types/system.ts
@@ -24,7 +24,6 @@ export interface HardwareStatus {
   psram: boolean;
   psram_size?: number;
   free_psram?: number;
-
   free_caps: number;
   model: string;
 }

--- a/interface/yarn.lock
+++ b/interface/yarn.lock
@@ -5,14 +5,14 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@alova/adapter-xhr@npm:2.0.4":
-  version: 2.0.4
-  resolution: "@alova/adapter-xhr@npm:2.0.4"
+"@alova/adapter-xhr@npm:2.0.5":
+  version: 2.0.5
+  resolution: "@alova/adapter-xhr@npm:2.0.5"
   dependencies:
     "@alova/shared": "npm:^1.0.4"
   peerDependencies:
-    alova: ^3.0.5
-  checksum: 10c0/c68f51b83c75844cf2cddc47d6e08fa7a6f0af83cc6213b60d0d8ac32988f8e7b44f321b1f926fa282a2cda02757ce3cbfe94e86f140fd025ab22f0dfee9bed9
+    alova: ^3.0.9
+  checksum: 10c0/9c48689e7dd081843726c4d8a93abbb7aca8b4654c606e67b81ab23de42542d5c17f2fbff7b65d4b75c7d484b42a74e76ba77e61446021620a256051eb82496c
   languageName: node
   linkType: hard
 
@@ -1664,7 +1664,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "EMS-ESP@workspace:."
   dependencies:
-    "@alova/adapter-xhr": "npm:2.0.4"
+    "@alova/adapter-xhr": "npm:2.0.5"
     "@babel/core": "npm:^7.25.2"
     "@emotion/react": "npm:^11.13.0"
     "@emotion/styled": "npm:^11.13.0"

--- a/lib/framework/UploadFileService.cpp
+++ b/lib/framework/UploadFileService.cpp
@@ -16,6 +16,7 @@ UploadFileService::UploadFileService(AsyncWebServer * server, SecurityManager * 
     : _securityManager(securityManager)
     , _is_firmware(false)
     , _md5() {
+    // end-points
     server->on(
         UPLOAD_FILE_PATH,
         HTTP_POST,
@@ -23,6 +24,10 @@ UploadFileService::UploadFileService(AsyncWebServer * server, SecurityManager * 
         [this](AsyncWebServerRequest * request, const String & filename, size_t index, uint8_t * data, size_t len, bool final) {
             handleUpload(request, filename, index, data, len, final);
         });
+
+    server->on(UPLOAD_URL_PATH,
+               securityManager->wrapCallback([this](AsyncWebServerRequest * request, JsonVariant json) { uploadURL(request, json); },
+                                             AuthenticationPredicates::IS_AUTHENTICATED));
 }
 
 void UploadFileService::handleUpload(AsyncWebServerRequest * request, const String & filename, size_t index, uint8_t * data, size_t len, bool final) {
@@ -113,7 +118,7 @@ void UploadFileService::handleUpload(AsyncWebServerRequest * request, const Stri
 }
 
 void UploadFileService::uploadComplete(AsyncWebServerRequest * request) {
-    // did we complete uploading a json file?
+    // did we just complete uploading a json file?
     if (request->_tempFile) {
         request->_tempFile.close(); // close the file handle as the upload is now done
         emsesp::EMSESP::system_.store_nvs_values();
@@ -166,4 +171,42 @@ void UploadFileService::handleError(AsyncWebServerRequest * request, int code) {
 void UploadFileService::handleEarlyDisconnect() {
     _is_firmware = false;
     Update.abort();
+}
+
+// upload firmware from a URL, like GitHub Release assets, Cloudflare R2 or Amazon S3
+void UploadFileService::uploadURL(AsyncWebServerRequest * request, JsonVariant json) {
+    if (json.is<JsonObject>()) {
+        String url = json["url"].as<String>();
+
+        // TODO fix this from WDT crashing
+        // calling from "test upload" in a console, it works
+        // but via the web it crashes with the error message:
+        //  E (253289) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
+        //  E (253289) task_wdt:  - async_tcp (CPU 0/1)
+        //  E (253289) task_wdt: Tasks currently running:
+        //  E (253289) task_wdt: CPU 0: ipc0
+        //  E (253289) task_wdt: CPU 1: loopTask
+        //  E (253289) task_wdt: Aborting.
+        //
+        // I think we need to stop all async services before uploading the firmware. Like MQTT?
+
+        // force close the connection
+        request->client()->close(true);
+
+        // start the upload
+        if (!emsesp::EMSESP::system_.uploadFirmwareURL(url.c_str())) {
+            emsesp::EMSESP::system_.upload_status(false); // tell ems-esp we're not uploading anymore
+        }
+
+        /*
+        if (!emsesp::EMSESP::system_.uploadFirmwareURL(url.c_str())) {
+            emsesp::EMSESP::system_.upload_status(false);
+            handleError(request, 500); // internal error, failed
+        } else {
+            request->onDisconnect(RestartService::restartNow);
+            AsyncWebServerResponse * response = request->beginResponse(200);
+            request->send(response);
+        }
+        */
+    }
 }

--- a/lib/framework/UploadFileService.h
+++ b/lib/framework/UploadFileService.h
@@ -13,7 +13,9 @@
 #include <array>
 
 #define UPLOAD_FILE_PATH "/rest/uploadFile"
-#define TEMP_FILENAME_PATH "/tmp_upload"
+#define UPLOAD_URL_PATH "/rest/uploadURL"
+
+#define TEMP_FILENAME_PATH "/tmp_upload" // for uploaded json files
 
 class UploadFileService {
   public:
@@ -27,6 +29,8 @@ class UploadFileService {
     void handleUpload(AsyncWebServerRequest * request, const String & filename, size_t index, uint8_t * data, size_t len, bool final);
     void uploadComplete(AsyncWebServerRequest * request);
     void handleError(AsyncWebServerRequest * request, int code);
+    void uploadURL(AsyncWebServerRequest * request, JsonVariant json);
+
     void handleEarlyDisconnect();
 };
 

--- a/mock-api/mockServer.js
+++ b/mock-api/mockServer.js
@@ -34,9 +34,10 @@ export default () => {
       server.middlewares.use(async (req, res, next) => {
         // catch any file uploads
         if (req.url.startsWith('/rest/uploadFile')) {
+          // show progress
           let progress = 0;
           const file_size = req.headers['content-length'];
-
+          console.log('File size: ' + file_size);
           req.on('data', async (chunk) => {
             progress += chunk.length;
             const percentage = (progress / file_size) * 100;
@@ -50,7 +51,7 @@ export default () => {
           try {
             [fields, files] = await form.parse(req);
           } catch (err) {
-            console.error(err);
+            console.error('Not json form content');
             res.writeHead(err.httpCode || 400, {
               'Content-Type': 'text/plain'
             });

--- a/mock-api/rest_server.ts
+++ b/mock-api/rest_server.ts
@@ -4666,10 +4666,15 @@ router
   .get(EMSESP_GET_SETTINGS_ENDPOINT, () => emsesp_info)
   .get(EMSESP_GET_CUSTOMIZATIONS_ENDPOINT, () => emsesp_deviceentities_1)
   .get(EMSESP_GET_ENTITIES_ENDPOINT, () => emsesp_customentities)
-  .get(EMSESP_GET_SCHEDULE_ENDPOINT, () => emsesp_schedule);
+  .get(EMSESP_GET_SCHEDULE_ENDPOINT, () => emsesp_schedule)
 
-// API which are usually POST for security
-router
+  // upload URL
+  .post('/rest/uploadURL', () => {
+    console.log('upload File from URL');
+    return status(200);
+  })
+
+  // API which are usually POST for security
   .post(EMSESP_SYSTEM_INFO_ENDPOINT, () => emsesp_info)
   .get(EMSESP_SYSTEM_INFO_ENDPOINT, () => emsesp_info)
   .post(API_ENDPOINT_ROOT, async (request: any) => {

--- a/src/emsesp.cpp
+++ b/src/emsesp.cpp
@@ -1671,11 +1671,13 @@ void EMSESP::loop() {
         mqtt_.loop();              // sends out anything in the MQTT queue
         webModulesService.loop();  // loop through the external library modules
         if (system_.PSram() == 0) {
-            webSchedulerService.loop();
+            webSchedulerService.loop(); // run non-async if there is no PSRAM available
         }
 
         // force a query on the EMS devices to fetch latest data at a set interval (1 min)
         scheduled_fetch_values();
+    } else {
+        emsesp::EMSESP::system_.uploadFirmwareURL(); // start an upload from a URL. This is blocking.
     }
 
     uuid::loop();

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -1833,31 +1833,51 @@ String System::getBBQKeesGatewayDetails() {
 #endif
 }
 
-// Stream from an URL and send straight to OTA uploader
+// Stream from an URL and send straight to OTA uploader service.
+//
+// This function needs to be called twice, once with a url to persist it, and second with no arguments to start the upload
+// This is to avoid timeouts in callback functions, like calling from a web hook.
 bool System::uploadFirmwareURL(const char * url) {
 #ifndef EMSESP_STANDALONE
-    // configure temporary server and url
-    HTTPClient http;
-    http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS); // important for GitHub
-    http.useHTTP10(true);
-    http.begin(String(url));
 
-    // start connection
+    static String saved_url;
+
+    // if the URL is not empty, save it for later
+    if (url && strlen(url) > 0) {
+        saved_url = url;
+        EMSESP::system_.upload_status(true); // tell EMS-ESP we're ready to start the uploading process
+        return true;
+    }
+
+    // make sure we have a valid URL
+    if (saved_url.isEmpty()) {
+        LOG_ERROR("Firmware upload failed - no URL");
+        return false;
+    }
+
+    // Configure temporary client
+    HTTPClient http;
+    http.setFollowRedirects(HTTPC_FORCE_FOLLOW_REDIRECTS); // important for GitHub 302's
+    http.useHTTP10(true);
+    http.begin(saved_url);
+
+    // start a connection
     int httpCode = http.GET();
     if (httpCode != HTTP_CODE_OK) {
         LOG_ERROR("Firmware upload failed - HTTP code %u", httpCode);
         return false;
     }
 
-    // check we have enough space
+    // check we have enough space for the upload in the ota partition
     int firmware_size = http.getSize();
-    LOG_INFO("Firmware uploading (file: %s, size: %d bytes)", url, firmware_size);
+    LOG_INFO("Firmware uploading (file: %s, size: %d bytes). Please wait...", saved_url.c_str(), firmware_size);
     if (!Update.begin(firmware_size)) {
         LOG_ERROR("Firmware upload failed - no space");
         return false;
     }
 
-    EMSESP::system_.upload_status(true); // tell EMS-ESP we're uploading
+    // flush buffers so latest log messages are shown
+    Shell::loop_all();
 
     // get tcp stream and send it to Updater
     WiFiClient * stream = http.getStreamPtr();
@@ -1867,54 +1887,22 @@ bool System::uploadFirmwareURL(const char * url) {
     }
 
     if (!Update.end(true)) {
-        LOG_ERROR("Firmware upload error");
+        LOG_ERROR("Firmware upload failed - general error");
         return false;
     }
 
     http.end();
 
+    EMSESP::system_.upload_status(false);
+    saved_url.clear(); // prevent from downloading again
+
     LOG_INFO("Firmware uploaded successfully. Restarting...");
 
-    restart_requested(true); // not sure this is needed?
+    restart_requested(true);
 
 #endif
 
     return true; // OK
-
-    /*
-    TODO backup code to save firmware to LittleFS first, in case of slow networks
-
-    // create buffer for reading in 128 byte chunks
-    const size_t buffer_size = 1024;
-    uint8_t buff[buffer_size] = {0};
-
-    File file = LittleFS.open("/new_firmware", "w"); // TODO find new name
-    if (!file) {
-        Serial.println("Failed to open file for writing");
-    return false;
-    }
-
-    // read all data from server
-    while (http.connected() && (firmware_size > 0 || firmware_size == -1)) {
-        // get available data size
-        size_t size = stream->available();
-
-        if (size) {
-            // read up to 128 byte
-            int c = stream->readBytes(buff, ((size > sizeof(buff)) ? sizeof(buff) : size));
-
-            file.write(buff, c);
-            if (firmware_size > 0) {
-                firmware_size -= c;
-            }
-        }
-        yield();
-        // delay(1); // so not to hurt WTD or timeout
-    }
-
-    file.close();
-
-    */
 }
 
 } // namespace emsesp

--- a/src/system.h
+++ b/src/system.h
@@ -100,7 +100,7 @@ class System {
 
     String getBBQKeesGatewayDetails();
 
-    static bool uploadFirmwareURL(const char * url);
+    static bool uploadFirmwareURL(const char * url = nullptr);
 
     void led_init(bool refresh);
     void network_init(bool refresh);

--- a/src/system.h
+++ b/src/system.h
@@ -100,6 +100,8 @@ class System {
 
     String getBBQKeesGatewayDetails();
 
+    static bool uploadFirmwareURL(const char * url);
+
     void led_init(bool refresh);
     void network_init(bool refresh);
     void button_init(bool refresh);

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -408,11 +408,16 @@ void Test::run_test(uuid::console::Shell & shell, const std::string & cmd, const
         ok = true;
     }
 
-// THESE ONLY WORK WITH AN ESP32, not in standalone mode
+// THESE ONLY WORK WITH AN ESP32, not in standalone/native mode
 #ifndef EMSESP_STANDALONE
     if (command == "ls") {
         listDir(LittleFS, "/", 3);
-        Serial.println();
+        ok = true;
+    }
+
+    if (command == "upload") {
+        // S3 has 16MB flash
+        EMSESP::system_.uploadFirmwareURL("https://github.com/emsesp/EMS-ESP32/releases/download/latest/EMS-ESP-3_7_0-dev_31-ESP32S3-16MB+.bin"); // TODO remove
         ok = true;
     }
 #endif
@@ -2278,7 +2283,9 @@ void Test::listDir(fs::FS & fs, const char * dirname, uint8_t levels) {
             Serial.print(" DIR: ");
             Serial.println(file.name());
             if (levels) {
-                listDir(fs, file.name(), levels - 1);
+                // prefix a / to the name to make it a full path
+                listDir(fs, ("/" + String(file.name())).c_str(), levels - 1);
+                // listDir(fs, file.name(), levels - 1);
             }
             Serial.println();
         } else {

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -58,6 +58,8 @@ namespace emsesp {
 // #define EMSESP_DEBUG_DEFAULT "custom"
 // #define EMSESP_DEBUG_DEFAULT "scheduler"
 // #define EMSESP_DEBUG_DEFAULT "heat_exchange"
+// #define EMSESP_DEBUG_DEFAULT "ls"
+#define EMSESP_DEBUG_DEFAULT "upload"
 
 #ifndef EMSESP_DEBUG_DEFAULT
 #define EMSESP_DEBUG_DEFAULT "general"

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define EMSESP_APP_VERSION "3.7.0-dev.31"
+#define EMSESP_APP_VERSION "3.7.0-dev.32"

--- a/src/web/WebStatusService.cpp
+++ b/src/web/WebStatusService.cpp
@@ -31,6 +31,12 @@ WebStatusService::WebStatusService(AsyncWebServer * server, SecurityManager * se
 }
 
 void WebStatusService::systemStatus(AsyncWebServerRequest * request) {
+    // This is a litle trick for the OTA upload. We don't want the React RestartService to think we're finished
+    // with the upload so we fake it and pretent the /rest/systemStatus is not available. That way the spinner keeps spinning.
+    if (EMSESP::system_.upload_status()) {
+        return; // ignore endpoint
+    }
+
     EMSESP::system_.refreshHeapMem(); // refresh free heap and max alloc heap
 
     auto *     response = new AsyncJsonResponse(false);


### PR DESCRIPTION
I thought I'd sneak this change in before my vacation. It adds the option to download and install the firmware automatically. UI looks like:

![image](https://github.com/user-attachments/assets/2bf0c0a6-6a22-4751-a08e-616a830e7e6f)

It works well when calling the function from the console with `test upload`. But calling it from within the Web instance by clicking on the button causes a WDT

```
$ E (253289) task_wdt: Task watchdog got triggered. The following tasks did not reset the watchdog in time:
E (253289) task_wdt:  - async_tcp (CPU 0/1)
E (253289) task_wdt: Tasks currently running:
E (253289) task_wdt: CPU 0: ipc0
E (253289) task_wdt: CPU 1: loopTask
E (253289) task_wdt: Aborting.
```

I think we need to close the connection (I tried this) but something is still blocking it. And I'm out of ideas. If you have time @MichaelDvP can you take a look?

See the code in `UploadFileService::uploadURL()` which calls `System::uploadFirmwareURL()`. Compile with -DEMSESP_TEST and then run `test update`. 

Note I hardcoded the calls to the GitHub API in `DownloadUpload.tsx` (lines 110-123) as GH was blocking them since I was testing too much!


 