### PR TITLE
some fixes

### DIFF
--- a/interface/src/app/main/Customizations.tsx
+++ b/interface/src/app/main/Customizations.tsx
@@ -268,10 +268,16 @@ const Customizations = () => {
 
   const formatName = (de: DeviceEntity, withShortname: boolean) =>
     (de.n && de.n[0] === '!'
-      ? LL.COMMAND(1) + ': ' + de.n.slice(1)
+      ? de.t
+        ? LL.COMMAND(1) + ': ' + de.t + ' ' + de.n.slice(1)
+        : LL.COMMAND(1) + ': ' + de.n.slice(1)
       : de.cn && de.cn !== ''
-        ? de.cn
-        : de.n) + (withShortname ? ' ' + de.id : '');
+        ? de.t
+          ? de.t + ' ' + de.cn
+          : de.cn
+        : de.t
+          ? de.t + ' ' + de.n
+          : de.n) + (withShortname ? ' ' + de.id : '');
 
   const getMaskNumber = (newMask: string[]) => {
     let new_mask = 0;
@@ -449,11 +455,14 @@ const Customizations = () => {
             <MenuItem disabled key={-1} value={-1}>
               {LL.SELECT_DEVICE()}...
             </MenuItem>
-            {devices.devices.map((device: Device) => (
-              <MenuItem key={device.id} value={device.id}>
-                {device.n}&nbsp;({device.tn})
-              </MenuItem>
-            ))}
+            {devices.devices.map(
+              (device: Device) =>
+                device.id < 90 && (
+                  <MenuItem key={device.id} value={device.id}>
+                    {device.n}&nbsp;({device.tn})
+                  </MenuItem>
+                )
+            )}
           </TextField>
         )}
         {selectedDevice !== -1 &&

--- a/interface/src/app/main/types.ts
+++ b/interface/src/app/main/types.ts
@@ -134,6 +134,7 @@ export interface DeviceEntity {
   v?: unknown; // value, in any format, optional
   n?: string; // fullname, optional
   cn?: string; // custom fullname, optional
+  t?: string; // tag for name
   m: DeviceEntityMask; // mask
   w: boolean; // writeable
   mi?: number; // min value

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -561,11 +561,7 @@ void Command::show(uuid::console::Shell & shell, uint8_t device_type, bool verbo
         }
     }
 
-    // non EMS devices always have an info, commands and values
-    bool show_info = (device_type == EMSdevice::DeviceType::TEMPERATURESENSOR || device_type == EMSdevice::DeviceType::ANALOGSENSOR
-                      || device_type == EMSdevice::DeviceType::SCHEDULER || device_type == EMSdevice::DeviceType::CUSTOM);
-
-    if (!verbose && show_info) {
+    if (!verbose) {
         sorted_cmds.push_back(F_(info));
         sorted_cmds.push_back(F_(commands));
         sorted_cmds.push_back(F_(values));
@@ -587,14 +583,12 @@ void Command::show(uuid::console::Shell & shell, uint8_t device_type, bool verbo
     shell.printfln("\n%s%s %s:%s", COLOR_BOLD_ON, COLOR_YELLOW, EMSdevice::device_type_2_device_name(device_type), COLOR_RESET);
 
     // we hard code 'info' and 'commands' commands so print them first
-    if (show_info) {
-        shell.printf("  info:\t\t\t\t%slist all values %s*", COLOR_BRIGHT_CYAN, COLOR_BRIGHT_GREEN);
-        shell.println(COLOR_RESET);
-        shell.printf("  commands:\t\t\t%slist all commands %s*", COLOR_BRIGHT_CYAN, COLOR_BRIGHT_GREEN);
-        shell.println(COLOR_RESET);
-        shell.printf("  values:\t\t\t%slist all values %s*", COLOR_BRIGHT_CYAN, COLOR_BRIGHT_GREEN);
-        shell.println(COLOR_RESET);
-    }
+    shell.printf("  info \t\t\t\t%slist all values %s*", COLOR_BRIGHT_CYAN, COLOR_BRIGHT_GREEN);
+    shell.println(COLOR_RESET);
+    shell.printf("  commands \t\t\t%slist all commands %s*", COLOR_BRIGHT_CYAN, COLOR_BRIGHT_GREEN);
+    shell.println(COLOR_RESET);
+    shell.printf("  values \t\t\t%slist all values %s*", COLOR_BRIGHT_CYAN, COLOR_BRIGHT_GREEN);
+    shell.println(COLOR_RESET);
 
     for (const auto & cl : sorted_cmds) {
         // find and print the description

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -553,7 +553,7 @@ static void setup_commands(std::shared_ptr<Commands> & commands) {
             if (return_code == CommandRet::OK) {
                 if (json.size()) {
                     if (json["api_data"].is<std::string>()) {
-                        String data = json["api_data"];
+                        std::string data = json["api_data"];
                         shell.println(data.c_str());
                         return;
                     }

--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -1080,7 +1080,8 @@ void EMSdevice::generate_values_web_customization(JsonArray output) {
         auto fullname = Helpers::translated_word(dv.fullname);
         if (dv.type != DeviceValueType::CMD) {
             if (fullname) {
-                obj["n"] = dv.has_tag() ? std::string(tag_to_string(dv.tag)) + " " + fullname : fullname; // prefix tag
+                // obj["n"] = dv.has_tag() ? std::string(tag_to_string(dv.tag)) + " " + fullname : fullname; // prefix tag
+                obj["n"] = fullname;
 
                 // TAG https://github.com/emsesp/EMS-ESP32/issues/1338
                 // obj["n"] = (dv.has_tag()) ? fullname + " " + tag_to_string(dv.tag) : fullname; // suffix tag
@@ -1094,7 +1095,9 @@ void EMSdevice::generate_values_web_customization(JsonArray output) {
         } else {
             obj["n"] = "!" + std::string(fullname); // prefix commands with a !
         }
-
+        if (dv.has_tag()) {
+            obj["t"] = tag_to_string(dv.tag);
+        }
         obj["m"] = dv.state >> 4; // send back the mask state. We're only interested in the high nibble
         obj["w"] = dv.has_cmd;    // if writable
 

--- a/src/emsdevice.cpp
+++ b/src/emsdevice.cpp
@@ -1684,7 +1684,7 @@ bool EMSdevice::generate_values(JsonObject output, const int8_t tag_filter, cons
             }
 
             // do not overwrite
-            if (json[name].is<const char *>()) {
+            if (json[name].is<JsonVariantConst>()) {
 #if defined(EMSESP_DEBUG)
                 EMSESP::logger().debug("warning: double json key: %s", name);
 #endif

--- a/src/web/WebCustomEntityService.cpp
+++ b/src/web/WebCustomEntityService.cpp
@@ -129,9 +129,9 @@ StateUpdateResult WebCustomEntity::update(JsonObject root, WebCustomEntity & web
             if (entityItem.writeable && !entityItem.name.empty()) {
                 Command::add(
                     EMSdevice::DeviceType::CUSTOM,
-                    entityItem.name.c_str(),
-                    [entityItem](const char * value, const int8_t id) {
-                        return EMSESP::webCustomEntityService.command_setvalue(value, id, entityItem.name.c_str());
+                    webCustomEntity.customEntityItems.back().name.c_str(),
+                    [webCustomEntity](const char * value, const int8_t id) {
+                        return EMSESP::webCustomEntityService.command_setvalue(value, id, webCustomEntity.customEntityItems.back().name.c_str());
                     },
                     FL_(entity_cmd),
                     CommandFlag::ADMIN_ONLY);


### PR DESCRIPTION
- custom entities commands not working, (entityItem.name.c_str() is local and not permanent)
- customizations naming with tags was odd, now change name but keep the tag.
- terminal `call` does not show info/values for ems devices anymore