### PR TITLE
dont show broken link if IMG cant be found

### DIFF
--- a/interface/src/app/main/Help.tsx
+++ b/interface/src/app/main/Help.tsx
@@ -37,6 +37,7 @@ const Help = () => {
 
   const [customSupportIMG, setCustomSupportIMG] = useState<string | null>(null);
   const [customSupportHTML, setCustomSupportHTML] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState<boolean>(false);
 
   useRequest(() => callAction({ action: 'customSupport' })).onSuccess((event) => {
     if (event && event.data && Object.keys(event.data).length !== 0) {
@@ -102,7 +103,12 @@ const Help = () => {
           sx={{
             maxHeight: { xs: 100, md: 250 }
           }}
-          src={customSupportIMG || 'https://emsesp.org/_media/images/installer.jpeg'}
+          onError={(e) => setNotFound(true)}
+          src={
+            notFound
+              ? ''
+              : customSupportIMG || 'https://emsesp.org/_media/images/installer.jpeg'
+          }
         />
       </Stack>
 

--- a/src/system.cpp
+++ b/src/system.cpp
@@ -791,9 +791,9 @@ void System::system_check() {
 #ifndef EMSESP_STANDALONE
 #if CONFIG_IDF_TARGET_ESP32S3 || CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32S2
 #if ESP_IDF_VERSION_MAJOR < 5
-    temp_sensor_read_celsius(&temperature_);
+        temp_sensor_read_celsius(&temperature_);
 #else
-    temperature_sensor_get_celsius(temperature_handle_, &temperature_);
+        temperature_sensor_get_celsius(temperature_handle_, &temperature_);
 #endif
 #endif
 #endif


### PR DESCRIPTION
When running in a closed network, or as its own Access Point, the help image will show a broken link on the Help web page