### PR TITLE
 fix analog input pullup and counter on gpio 25/26, dac values on web #2201 

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -23,5 +23,6 @@ For more details go to [www.emsesp.org](https://www.emsesp.org/).
 - lastCode character check [#2189](https://github.com/emsesp/EMS-ESP32/issues/2189)
 - reading too many telegram parts
 - heatpump cost UOMs [#2188](https://github.com/emsesp/EMS-ESP32/issues/2188)
+- analog dac output and inputs on dac pins [#2201](https://github.com/emsesp/EMS-ESP32/discussions/2201)
 
 ## Changed

--- a/interface/src/app/main/Sensors.tsx
+++ b/interface/src/app/main/Sensors.tsx
@@ -438,7 +438,8 @@ const Sensors = () => {
                 <Cell stiff>{a.g}</Cell>
                 <Cell>{a.n}</Cell>
                 <Cell stiff>{AnalogTypeNames[a.t]} </Cell>
-                {a.t === AnalogType.DIGITAL_OUT || a.t === AnalogType.DIGITAL_IN ? (
+                {(a.t === AnalogType.DIGITAL_OUT && a.g !== 25 && a.g !== 26) ||
+                a.t === AnalogType.DIGITAL_IN ? (
                   <Cell stiff>{a.v ? LL.ON() : LL.OFF()}</Cell>
                 ) : (
                   <Cell stiff>{a.t ? formatValue(a.v, a.u) : ''}</Cell>

--- a/src/analogsensor.cpp
+++ b/src/analogsensor.cpp
@@ -147,7 +147,7 @@ void AnalogSensor::reload(bool get_nvs) {
                 dacWrite(sensor.gpio(), 255);
             }
 #elif CONFIG_IDF_TARGET_ESP32S2
-            if (sensor.gpio() == 23 || sensor.gpio() == 24) {
+            if (sensor.gpio() == 17 || sensor.gpio() == 18) {
                 dacWrite(sensor.gpio(), 255);
             }
 #endif
@@ -197,7 +197,7 @@ void AnalogSensor::reload(bool get_nvs) {
                 sensor.set_value(sensor.offset());
             } else
 #elif CONFIG_IDF_TARGET_ESP32S2
-            if (sensor.gpio() == 23 || sensor.gpio() == 24) {
+            if (sensor.gpio() == 17 || sensor.gpio() == 18) {
                 if (sensor.offset() > 255) {
                     sensor.set_offset(255);
                 } else if (sensor.offset() < 0) {
@@ -750,7 +750,7 @@ bool AnalogSensor::command_setvalue(const char * value, const int8_t gpio) {
                     dacWrite(sensor.gpio(), sensor.offset());
                 } else
 #elif CONFIG_IDF_TARGET_ESP32S2
-                if ((sensor.gpio() == 23 || sensor.gpio() == 24) && v <= 255) {
+                if ((sensor.gpio() == 17 || sensor.gpio() == 18) && v <= 255) {
                     sensor.set_offset(v);
                     sensor.set_value(v);
                     pinMode(sensor.gpio(), OUTPUT);

--- a/src/version.h
+++ b/src/version.h
@@ -1,1 +1,1 @@
-#define EMSESP_APP_VERSION "3.7.1-dev.6"
+#define EMSESP_APP_VERSION "3.7.1-dev.7"

--- a/src/web/WebDataService.cpp
+++ b/src/web/WebDataService.cpp
@@ -415,7 +415,16 @@ void WebDataService::dashboard_data(AsyncWebServerRequest * request) {
 
                 JsonObject dv = node["dv"].to<JsonObject>();
                 dv["id"]      = "00" + sensor.name();
-                if (sensor.type() == AnalogSensor::AnalogType::DIGITAL_OUT || sensor.type() == AnalogSensor::AnalogType::DIGITAL_IN) {
+#if CONFIG_IDF_TARGET_ESP32
+                if (sensor.type() == AnalogSensor::AnalogType::DIGITAL_OUT && (sensor.gpio() == 25 || sensor.gpio() == 26)) {
+                    obj["v"] = Helpers::transformNumFloat(sensor.value(), 0);
+                } else
+#elif CONFIG_IDF_TARGET_ESP32S2
+                if (sensor.type() == AnalogSensor::AnalogType::DIGITAL_OUT && (sensor.gpio() == 17 || sensor.gpio() == 18)) {
+                    obj["v"] = Helpers::transformNumFloat(sensor.value(), 0);
+                } else
+#endif
+                    if (sensor.type() == AnalogSensor::AnalogType::DIGITAL_OUT || sensor.type() == AnalogSensor::AnalogType::DIGITAL_IN) {
                     char s[12];
                     dv["v"]     = Helpers::render_boolean(s, sensor.value() != 0, true);
                     JsonArray l = dv["l"].to<JsonArray>();


### PR DESCRIPTION
I think the documentation is still ok. 
One of the pin links seems broken and the valid pins only listed for esp32, not for the s3 chip.
S2 have a DAC (S3 not) on pin 23/24, but these pin are gpio 17/18. 
Seems to be much work to display S2 dac on web correctly, skipped it as we have no official S2 support.