### PR TITLE
Fix console unit tests due to changed shell output

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -28,6 +28,7 @@ For more details go to [docs.emsesp.org](https://docs.emsesp.org/).
 - thermostat date [#2313](https://github.com/emsesp/EMS-ESP32/issues/2313)
 - Updated unknown compressor stati "enum_hpactivity" [#2311](https://github.com/emsesp/EMS-ESP32/pull/2311)
 - Underline Tab headers in WebUI
+- console unit tests fixed due to changed shell output
 
 ## Changed
 

--- a/test/test_api/test_api.cpp
+++ b/test/test_api/test_api.cpp
@@ -292,13 +292,16 @@ void run_manual_tests() {
 const char * run_console_command(const char * command) {
     output_buffer[0] = '\0'; // empty the temp buffer
     shell->invoke_command(command);
-    // remove everything before \r\n
+
+    // The buffer now contains a prompt, the command, the output and a \r\n
+    // remove the \r\n at the end
     char * p = strstr(output_buffer, "\r\n");
     if (p) {
-        p += 2; // skip the \r\n
+        *p = '\0';
     }
-    // remove the \r\n at the end
-    p[strlen(p) - 2] = '\0';
+
+    // Now go to just after the prompt and command
+    p = output_buffer + 7 + strlen(command);
 
     // Serial.println("Output:");
     // Serial.print(p);


### PR DESCRIPTION
On the current dev branch the console unit tests are failing with a seg fault. This is coming from the string handling for the output from the uuid-console shell class, which appears to have changed. 

I've changed the handling - this is only in test code.