### PR TITLE
use messagetime in WebLogService::show() #2533

### DIFF
--- a/interface/package.json
+++ b/interface/package.json
@@ -47,7 +47,7 @@
     "@preact/compat": "^18.3.1",
     "@preact/preset-vite": "^2.10.1",
     "@trivago/prettier-plugin-sort-imports": "^5.2.2",
-    "@types/node": "^22.15.1",
+    "@types/node": "^22.15.2",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "concurrently": "^9.1.2",

--- a/interface/yarn.lock
+++ b/interface/yarn.lock
@@ -1408,12 +1408,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.15.1":
-  version: 22.15.1
-  resolution: "@types/node@npm:22.15.1"
+"@types/node@npm:^22.15.2":
+  version: 22.15.2
+  resolution: "@types/node@npm:22.15.2"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/80bd7fff7d6f4058875feb2c980fa066266b02ffde51e794cf4b7bea5f1316c08baa135fa7cbffa677efb999b0945b2697b318e84af4563c1ab8d3392a17bf9a
+  checksum: 10c0/39da31d5fc63b14fabd217bb8a921c4a7fc3d99f233440209f9fc2d5d736e8773f7efc65223e2fd0e8db8390b0baab9c0cd2e951c2ece8b237f07313ab3cf295
   languageName: node
   linkType: hard
 
@@ -1603,7 +1603,7 @@ __metadata:
     "@preact/preset-vite": "npm:^2.10.1"
     "@table-library/react-table-library": "npm:4.1.15"
     "@trivago/prettier-plugin-sort-imports": "npm:^5.2.2"
-    "@types/node": "npm:^22.15.1"
+    "@types/node": "npm:^22.15.2"
     "@types/react": "npm:^19.1.2"
     "@types/react-dom": "npm:^19.1.2"
     alova: "npm:3.2.10"

--- a/src/web/WebLogService.h
+++ b/src/web/WebLogService.h
@@ -70,8 +70,7 @@ class WebLogService : public uuid::log::Handler {
     unsigned long                log_message_id_       = 0;                // The next identifier to use for queued log messages
     unsigned long                log_message_id_tail_  = 0;                // last event shown on the screen after fetch
     std::deque<QueuedLogMessage> log_messages_;                            // Queued log messages, in the order they were received
-    time_t                       time_offset_ = 0;
-    bool                         compact_     = true;
+    bool                         compact_ = true;
 };
 
 } // namespace emsesp


### PR DESCRIPTION
and get the time offset when showing the message, not when storing it. 
So `show log` will show all buffered messages with real time also the messages before NTP was started.