### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stable_release.yml
+++ b/.github/workflows/stable_release.yml
@@ -1,5 +1,8 @@
 name: 'Build stable release'
 
+permissions:
+  contents: write
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/emsesp/EMS-ESP32/security/code-scanning/36](https://github.com/emsesp/EMS-ESP32/security/code-scanning/36)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the workflow. Based on the steps in the workflow:
- The "Create GitHub Release" step requires `contents: write`.
- Other steps, such as checking out the repository and installing dependencies, only require `contents: read`.

We will set `contents: write` at the root level to cover all jobs, as this is the minimal required permission for the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
