### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -6,10 +6,15 @@ on:
     branches:
       - 'dev2'
 
+permissions:
+  contents: read
+
 jobs:
   pre-release:
     name: 'Build Test Release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
 
       - name: Install python 3.13


### PR DESCRIPTION
Potential fix for [https://github.com/emsesp/EMS-ESP32/security/code-scanning/35](https://github.com/emsesp/EMS-ESP32/security/code-scanning/35)

To fix the issue, we will add a `permissions` block to the workflow. At the workflow level, we will set `contents: read` as the default permission, which is sufficient for most steps. For the `Create GitHub Release` step, we will override the permissions to include `contents: write`, as it requires write access to create a release. This approach ensures minimal permissions are granted while allowing the workflow to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
