### PR TITLE
Potential fix for code scanning alert no. 34: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev_release.yml
+++ b/.github/workflows/dev_release.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - 'dev'
 
+permissions:
+  contents: write
+
 jobs:
   pre-release:
     name: 'Build Dev Release'


### PR DESCRIPTION
Potential fix for [https://github.com/emsesp/EMS-ESP32/security/code-scanning/34](https://github.com/emsesp/EMS-ESP32/security/code-scanning/34)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required for the workflow to function. Based on the steps in the workflow:
- `contents: read` is needed for actions like `actions/checkout` to read the repository contents.
- `contents: write` is required for the `emsesp/action-automatic-releases` step to create a release.
- No other permissions appear to be necessary.

The `permissions` block will be added at the root level to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
