### PR TITLE
Potential fix for code scanning alert no. 38: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -1,4 +1,8 @@
 name: "Mark or close stale issues and PRs"
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
  
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/emsesp/EMS-ESP32/security/code-scanning/38](https://github.com/emsesp/EMS-ESP32/security/code-scanning/38)

The best way to fix the problem is to add a `permissions` block to the workflow or to the individual job that uses the GITHUB_TOKEN. Since only the `stale` job is present, adding the permissions directly under that job is idiomatic, but adding it at the root of the workflow (above `jobs:`) is also acceptable and will apply to all jobs in the file. The permissions should be scoped to the minimum necessary for the actions being performed: writing to issues and pull requests, and possibly `contents: write` if the action needs it (usually contents: read suffices). 

In detail, edit the `.github/workflows/stale_issues.yml` file, and add the following lines:

- For workflow-level permissions (recommended for single-job workflows), insert:
  ```
  permissions:
    contents: read
    issues: write
    pull-requests: write
  ```
  directly after the workflow `name:` and before the `on:` block.  

Alternatively, you could add the same block under the `stale` job (`jobs.stale.permissions:`), but workflow-level is preferred for single-job workflows.

No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
