### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -1,4 +1,6 @@
 name: 'Pre-check on PR'
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/emsesp/EMS-ESP32/security/code-scanning/40](https://github.com/emsesp/EMS-ESP32/security/code-scanning/40)

The best way to fix the problem is to explicitly add a `permissions` block to the workflow, restricting the GITHUB_TOKEN to only those permissions required for this workflow. Since the job only checks out code and runs local tests, the only permission needed is `contents: read`. The `permissions` block can be added either at the workflow root (to apply to all jobs) or within the `jobs.pre-release` job itself. For clarity and future extensibility, adding it just before the `jobs:` block at the workflow root ensures all future jobs in this workflow will default to least privilege. Required changes: add the following block after the workflow name, before `on:`, in `.github/workflows/pr_check.yml`:
```yaml
permissions:
  contents: read
```
No imports or library modifications are needed—just a change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
