### PR TITLE
Potential fix for code scanning alert no. 41: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/github-releases-to-discord.yml
+++ b/.github/workflows/github-releases-to-discord.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/emsesp/EMS-ESP32/security/code-scanning/41](https://github.com/emsesp/EMS-ESP32/security/code-scanning/41)

To fix the problem, explicitly limit the permissions granted to jobs in the workflow. Since the only visible job here is `github-releases-to-discord`, and its steps do not appear to require more than read access to repository contents, we should add a `permissions` block with `contents: read`. This block should be added at the job level (inside `github-releases-to-discord:`), immediately alongside `runs-on:` and `steps:`. No new methods, imports, or definitions are needed; only the addition of a few YAML lines.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
