### PR TITLE
validate board gpios in system

### DIFF
--- a/interface/src/app/main/SensorsAnalogDialog.tsx
+++ b/interface/src/app/main/SensorsAnalogDialog.tsx
@@ -172,30 +172,21 @@ const SensorsAnalogDialog = ({
       <DialogTitle>{dialogTitle}</DialogTitle>
       <DialogContent dividers>
         <Grid container spacing={2}>
-          {editItem.s ? (
-            <TextField
-              name="g"
-              label="GPIO"
-              value={editItem.g}
-              sx={{ width: '8ch' }}
-              disabled={true}
-            ></TextField>
-          ) : (
-            <ValidatedTextField
-              name="g"
-              label="GPIO"
-              value={editItem.g}
-              sx={{ width: '8ch' }}
-              select
-              onChange={updateFormValue}
-            >
-              {availableGPIOs?.map((gpio: number) => (
-                <MenuItem key={gpio} value={gpio}>
-                  {gpio}
-                </MenuItem>
-              ))}
-            </ValidatedTextField>
-          )}
+          <ValidatedTextField
+            name="g"
+            label="GPIO"
+            value={editItem.g}
+            sx={{ width: '8ch' }}
+            disabled={editItem.s}
+            select
+            onChange={updateFormValue}
+          >
+            {availableGPIOs?.map((gpio: number) => (
+              <MenuItem key={gpio} value={gpio}>
+                {gpio}
+              </MenuItem>
+            ))}
+          </ValidatedTextField>
           <Grid>
             <ValidatedTextField
               name="n"

--- a/src/core/console.cpp
+++ b/src/core/console.cpp
@@ -357,7 +357,7 @@ static void setup_commands(std::shared_ptr<Commands> const & commands) {
                                   shell.printfln(F_(tx_mode_fmt), settings.tx_mode);
                                   return StateUpdateResult::CHANGED;
                               });
-                              EMSESP::uart_init();
+                              EMSESP::system_.uart_init(false);
                           });
 
     //

--- a/src/core/emsesp.cpp
+++ b/src/core/emsesp.cpp
@@ -240,36 +240,6 @@ void EMSESP::watch_id(uint16_t watch_id) {
     watch_id_ = watch_id;
 }
 
-// resets all counters and bumps the UART
-// this is called when the tx_mode is persisted in the FS either via Web UI or the console
-void EMSESP::uart_init() {
-    uint8_t tx_mode = 0;
-    uint8_t rx_gpio = 0;
-    uint8_t tx_gpio = 0;
-    EMSESP::webSettingsService.read([&](WebSettings const & settings) {
-        tx_mode = settings.tx_mode;
-        rx_gpio = settings.rx_gpio;
-        tx_gpio = settings.tx_gpio;
-    });
-
-    EMSuart::stop();
-
-    // don't start UART if we have invalid GPIOs
-    if (EMSESP::system_.is_valid_gpio(rx_gpio) && EMSESP::system_.is_valid_gpio(tx_gpio)) {
-        EMSuart::start(tx_mode, rx_gpio, tx_gpio); // start UART
-    } else {
-        LOG_WARNING("Invalid UART Rx/Tx GPIOs. Check config.");
-    }
-
-    txservice_.start(); // sends out request to EMS bus for all devices
-    txservice_.tx_mode(tx_mode);
-
-    // force a fetch for all new values, unless Tx is set to off
-    // if (tx_mode != 0) {
-    // EMSESP::fetch_device_values();
-    // }
-}
-
 // return status of bus: connected (0), connected but Tx is broken (1), disconnected (2)
 uint8_t EMSESP::bus_status() {
     if (!rxservice_.bus_connected()) {

--- a/src/core/emsesp.h
+++ b/src/core/emsesp.h
@@ -147,8 +147,6 @@ class EMSESP {
     static void dump_all_entities(uuid::console::Shell & shell);
     static void dump_all_telegrams(uuid::console::Shell & shell);
 
-    static void uart_init();
-
     static void incoming_telegram(uint8_t * data, const uint8_t length);
 
     static bool sensor_enabled() {

--- a/src/core/system.h
+++ b/src/core/system.h
@@ -133,6 +133,7 @@ class System {
     void network_init(bool refresh);
     void button_init(bool refresh);
     void commands_init();
+    void uart_init(bool refresh);
 
     void    systemStatus(uint8_t status_code);
     uint8_t systemStatus();
@@ -144,6 +145,10 @@ class System {
     static bool load_board_profile(std::vector<int8_t> & data, const std::string & board_profile);
 
     static bool readCommand(const char * data);
+
+    void dallas_gpio(uint8_t gpio) {
+        dallas_gpio_ = gpio;
+    }
 
     bool telnet_enabled() {
         return telnet_enabled_;
@@ -413,6 +418,7 @@ class System {
     uint8_t     pbutton_gpio_;
     uint8_t     rx_gpio_;
     uint8_t     tx_gpio_;
+    uint8_t     tx_mode_;
     uint8_t     dallas_gpio_;
     bool        telnet_enabled_;
     bool        syslog_enabled_;

--- a/src/core/temperaturesensor.cpp
+++ b/src/core/temperaturesensor.cpp
@@ -55,10 +55,12 @@ void TemperatureSensor::start(const bool factory_settings) {
 // load settings
 void TemperatureSensor::reload() {
     // load the service settings
+    EMSESP::system_.dallas_gpio(0); // reset in system to check valid sensor
     EMSESP::webSettingsService.read([&](WebSettings const & settings) {
-        dallas_gpio_ = settings.dallas_gpio;
+        dallas_gpio_ = EMSESP::system_.is_valid_gpio(settings.dallas_gpio) ? settings.dallas_gpio : 0;
         parasite_    = settings.dallas_parasite;
     });
+    EMSESP::system_.dallas_gpio(dallas_gpio_); // set to system for checks
 
     for (auto & sensor : sensors_) {
         remove_ha_topic(sensor.id());

--- a/src/web/WebSettingsService.cpp
+++ b/src/web/WebSettingsService.cpp
@@ -409,7 +409,7 @@ void WebSettingsService::onUpdate() {
     }
 
     if (WebSettings::has_flags(WebSettings::ChangeFlags::UART)) {
-        EMSESP::uart_init();
+        EMSESP::system_.uart_init(true);
     }
 
     if (WebSettings::has_flags(WebSettings::ChangeFlags::SYSLOG)) {


### PR DESCRIPTION
There is no feedback in web, but the log should warn. Invalid gpios are set to zero, means `off`  for dallas, led, uart, etc. Only button is allowed for gpio 0, many boards have a boot-button on gpio 0.
Have not count up the version, please test first. On my GH i have a manual triggert build.