### PR TITLE
Update mqtt.cpp: use the same nomenclature as Tasmota and OpenBK uses…

### DIFF
--- a/src/core/mqtt.cpp
+++ b/src/core/mqtt.cpp
@@ -562,8 +562,8 @@ void Mqtt::ha_status() {
 // Note we don't use camelCase as it would change the HA entity_id and impact historic data
 #ifndef EMSESP_STANDALONE
     if (!EMSESP::system_.ethernet_connected() || WiFi.isConnected()) {
-        publish_system_ha_sensor_config(DeviceValueType::INT8, "WiFi RSSI", "rssi", DeviceValueUOM::DBM);
-        publish_system_ha_sensor_config(DeviceValueType::INT8, "WiFi strength", "wifistrength", DeviceValueUOM::PERCENT);
+        publish_system_ha_sensor_config(DeviceValueType::INT8, "RSSI", "rssi", DeviceValueUOM::DBM);
+        publish_system_ha_sensor_config(DeviceValueType::INT8, "Signal", "wifistrength", DeviceValueUOM::PERCENT);
     }
 #endif
 


### PR DESCRIPTION
… for Homeassistant

to be compliant to the HA typical nomenclatura use the same wording.

since we are anyway connecting via wifi or ethernet the wording of "WIFI rssi" is redundant. just use "RSSI" as other platforms do.

<img width="790" height="284" alt="image" src="https://github.com/user-attachments/assets/cb17f123-50f9-422e-b103-287fe517d570" />
