### PR TITLE
fix board change ignore old gpio settings

### DIFF
--- a/src/core/mqtt.cpp
+++ b/src/core/mqtt.cpp
@@ -1167,6 +1167,8 @@ void Mqtt::add_ha_classes(JsonObject doc, const uint8_t device_type, const uint8
         doc[uom_ha] = "L/min";
     } else if (uom == DeviceValueUOM::LH) {
         doc[uom_ha] = "L/h";
+    } else if (uom == DeviceValueUOM::L) {
+        doc[uom_ha] = "L";
     } else if (uom != DeviceValueUOM::NONE) {
         doc[uom_ha] = EMSdevice::uom_to_string(uom); // use default
     } else if (discovery_type() != discoveryType::HOMEASSISTANT) {

--- a/src/web/WebSettingsService.cpp
+++ b/src/web/WebSettingsService.cpp
@@ -308,8 +308,8 @@ StateUpdateResult WebSettings::update(JsonObject root, WebSettings & settings) {
     }
 
     // save the settings if changed from the webUI
-    // if we encountered an invalid GPIO on same boardprofile, rollback changes and don't save settings, and report the error to WebUI
-    // without a restart
+    // if we encountered an invalid GPIO on same boardprofile, rollback changes and don't save settings,
+    // and report the error to WebUI without a restart
     if (!have_valid_gpios && original_settings.board_profile == settings.board_profile) {
         // replace settings with original settings
         settings = original_settings;


### PR DESCRIPTION
A blank S3Mini board is initially detected as BBQKees S3, but board change to Lilygo S3 Mini is not possible because of invalid GPIO8.
I could select CUSTOM with old gpios, restart and then change to S3mini. 

With this change there is still an error shown, but it restarts with new board and loads the right settings.

Log when changing (calls WebSettingsService::board_profile with fails before rebooting)
```
2026-01-10T16:04:27.083 I 27: [emsesp] Loaded board profile S3MINI
2026-01-10T16:04:27.083 D 28: [system] GPIO 2 removed from used gpio list
2026-01-10T16:04:27.083 D 29: [system] GPIO 18 removed from used gpio list
2026-01-10T16:04:27.083 D 30: [system] GPIO 0 removed from used gpio list
2026-01-10T16:04:27.083 D 31: [system] GPIO 5 removed from used gpio list
2026-01-10T16:04:27.083 D 32: [system] GPIO 17 removed from used gpio list
2026-01-10T16:04:27.083 W 33: [system] GPIO 8 for UART Rx is not valid
2026-01-10T16:04:27.083 D 34: [system] Adding GPIO 5 for UART Tx to used gpio list
2026-01-10T16:04:27.083 D 35: [system] Adding GPIO 17 for LED to used gpio list
2026-01-10T16:04:27.083 D 36: [system] Adding GPIO 18 for Dallas to used gpio list
2026-01-10T16:04:27.083 D 37: [system] Adding GPIO 0 for Button to used gpio list
2026-01-10T16:04:29.601 D 38: [system] GPIO 17 removed from used gpio list
2026-01-10T16:04:29.601 D 39: [system] GPIO 18 removed from used gpio list
2026-01-10T16:04:29.601 D 40: [system] GPIO 0 removed from used gpio list
2026-01-10T16:04:29.601 D 41: [system] GPIO 5 removed from used gpio list
2026-01-10T16:04:29.601 W 42: [system] GPIO 8 for UART Rx is not valid
2026-01-10T16:04:29.601 D 43: [system] Adding GPIO 5 for UART Tx to used gpio list
2026-01-10T16:04:29.601 D 44: [system] Adding GPIO 17 for LED to used gpio list
2026-01-10T16:04:29.601 D 45: [system] Adding GPIO 18 for Dallas to used gpio list
2026-01-10T16:04:29.601 D 46: [system] Adding GPIO 0 for Button to used gpio list
2026-01-10T16:04:29.601 D 47: [system] Setting System status code 6
2026-01-10T16:04:29.623 I 48: [system] Restarting EMS-ESP...
2026-01-10T16:04:29.623 D 49: [system] Setting System status code 0
```