### PR TITLE
fix allowed pins for S32S3 without PSRAM

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -2952,7 +2952,6 @@ void System::set_valid_system_gpios() {
     // excluded:
     // GPIO3, GPIO45 - GPIO46 = strapping pins
     // GPIO26 - GPIO32 = SPI flash and PSRAM and not recommended
-    // GPIO33 - GPIO37 = Octal flash/PSRAM
     // GPIO19 - GPIO20 = USB-JTAG
     // GPIO22 - GPIO25 = don't exist
     //
@@ -2960,7 +2959,12 @@ void System::set_valid_system_gpios() {
     // GPIO11 - GPIO19 = ADC analog input only pins
     // GPIO47 - GPIO48 = valid on a Wemos S3
     // GPIO8 = used by Liligo S3 board profile for Rx
-    valid_system_gpios_ = string_range_to_vector("0-48", "3, 45-46, 26-32, 33-37, 19-20, 22-25");
+    if (ESP.getPsramSize() > 0) {
+        // GPIO33 - GPIO37 = Octal flash/PSRAM
+        valid_system_gpios_ = string_range_to_vector("0-48", "3, 45-46, 26-32, 33-37, 19-20, 22-25");
+    } else {
+        valid_system_gpios_ = string_range_to_vector("0-48", "3, 45-46, 26-32, 19-20, 22-25");
+    }
 
 #elif CONFIG_IDF_TARGET_ESP32
     // https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/peripherals/gpio.html


### PR DESCRIPTION
Some S32S3 do not have PSRAM (e.g. ESP32-S3FN8) and use those GPIO pins

Fixes #2974 