### PR TITLE
Fix RC300Holiday telegram length for inclusion of HC/DHW mode & assignment

### DIFF
--- a/src/devices/thermostat.cpp
+++ b/src/devices/thermostat.cpp
@@ -202,7 +202,7 @@ Thermostat::Thermostat(uint8_t device_type, uint8_t device_id, uint8_t product_i
         if (model == EMSdevice::EMS_DEVICE_FLAG_RC100) {
             register_telegram_type(0x43F, "CRHolidays", true, MAKE_PF_CB(process_RC300Holiday), 6);
         } else {
-            register_telegram_type(0x269, "RC300Holiday", true, MAKE_PF_CB(process_RC300Holiday), 6);
+            register_telegram_type(0x269, "RC300Holiday", true, MAKE_PF_CB(process_RC300Holiday), 14);
         }
         register_telegram_type(0x16E, "Absent", true, MAKE_PF_CB(process_Absent), 1);
         register_telegram_type(0xBF, "ErrorMessage", false, MAKE_PF_CB(process_ErrorMessageBF));


### PR DESCRIPTION
**Problem:** The `0x269` holiday telegram is registered with fetch size `6`, covering only the date bytes (offsets 0–5). Custom entities targeting HC/DHW assignment bytes (offsets 9–13, documented in #2866) cannot be read because the custom entity `fetch()` logic defers to the device driver's fetch when `is_fetch(0x269)` is true — meaning only 6 bytes are ever polled. The DHW byte at offset 13 is never received, see #2467 (@drheck).

**Fix:** Increase fetch size from `6` to `14` so the full HC/DHW assignment block is included in the polled response. The `process_RC300Holiday` handler is unaffected — it still only processes the first 6 bytes.