### PR TITLE
fix warning "esp32-hal-gpio.c:181] __digitalWrite(): IO 2 is not set …

### DIFF
--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -840,11 +840,6 @@ void System::button_init() {
 
 // set the LED to on or off when in normal operating mode
 void System::led_init() {
-    // RGB: drive strip low before init. Standard GPIO LED: pinMode must precede digitalWrite (ESP32 Arduino hal).
-    if (led_type_) {
-        EMSESP_RGB_WRITE(led_gpio_, 0, 0, 0);
-    }
-
     if (!led_gpio_) { // 0 means disabled
         LOG_INFO("LED disabled");
         return;

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -840,19 +840,21 @@ void System::button_init() {
 
 // set the LED to on or off when in normal operating mode
 void System::led_init() {
-    // disabled old led port before setting new one
-    led_type_ ? EMSESP_RGB_WRITE(led_gpio_, 0, 0, 0) : digitalWrite(led_gpio_, !LED_ON);
+    // RGB: drive strip low before init. Standard GPIO LED: pinMode must precede digitalWrite (ESP32 Arduino hal).
+    if (led_type_) {
+        EMSESP_RGB_WRITE(led_gpio_, 0, 0, 0);
+    }
 
-    if ((led_gpio_)) { // 0 means disabled
-        if (led_type_) {
-            // rgb LED WS2812B, use Neopixel
-            EMSESP_RGB_WRITE(led_gpio_, 0, 0, 0);
-        } else {
-            pinMode(led_gpio_, OUTPUT);
-            digitalWrite(led_gpio_, !LED_ON); // start with LED off
-        }
-    } else {
+    if (!led_gpio_) { // 0 means disabled
         LOG_INFO("LED disabled");
+        return;
+    }
+
+    if (led_type_) {
+        EMSESP_RGB_WRITE(led_gpio_, 0, 0, 0);
+    } else {
+        pinMode(led_gpio_, OUTPUT);
+        digitalWrite(led_gpio_, !LED_ON); // start with LED off
     }
 }
 

--- a/src/web/WebStatusService.cpp
+++ b/src/web/WebStatusService.cpp
@@ -372,13 +372,11 @@ void WebStatusService::getVersions(JsonObject root) {
 // schedule the next versions.json fetch a few seconds out so the network stack has time to settle
 // (DHCP completion, default-netif assignment and DNS server propagation through lwip)
 void WebStatusService::schedule_versions_refresh() {
-#ifndef EMSESP_STANDALONE
     uint32_t next = uuid::get_uptime() + VERSIONS_INITIAL_FETCH_DELAY_MS;
     if (next == 0) {
         next = 1; // 0 is the "idle" sentinel — never let the wrap land there
     }
     versions_next_fetch_ms_ = next;
-#endif
 }
 
 // periodic refresh (1 hour) of the cached versions.json


### PR DESCRIPTION
When EMS-ESP boots on a E32V one of the first visible errors in the log is

`esp32-hal-gpio.c:181] __digitalWrite(): IO 2 is not set as GPIO. Execute digitalMode(2, OUTPUT) first`
