### PR TITLE
reset system status

### DIFF
--- a/src/core/emsesp.cpp
+++ b/src/core/emsesp.cpp
@@ -1864,16 +1864,9 @@ void EMSESP::loop() {
     webLogService.loop(); // log in Web UI
 
     // run the loop, unless we're in the middle of an OTA upload
-    if (EMSESP::system_.systemStatus() == SYSTEM_STATUS::SYSTEM_STATUS_NORMAL || EMSESP::system_.systemStatus() == SYSTEM_STATUS::SYSTEM_STATUS_INVALID_GPIO) {
-        // check for GPIO Errors - this is called once when booting
-        if (EMSESP::system_.systemStatus() == SYSTEM_STATUS::SYSTEM_STATUS_INVALID_GPIO) {
-            static bool only_once = false;
-            if (!only_once) {
-                LOG_ERROR("Invalid GPIOs used. Please check your settings and the system log");
-                only_once = true;
-            }
-        }
-
+    // if (EMSESP::system_.systemStatus() == SYSTEM_STATUS::SYSTEM_STATUS_NORMAL || EMSESP::system_.systemStatus() == SYSTEM_STATUS::SYSTEM_STATUS_INVALID_GPIO) {
+    if (EMSESP::system_.systemStatus() != SYSTEM_STATUS::SYSTEM_STATUS_PENDING_UPLOAD
+        && EMSESP::system_.systemStatus() != SYSTEM_STATUS::SYSTEM_STATUS_UPLOADING) {
         // loop through the services
         rxservice_.loop();          // process any incoming Rx telegrams
         shower_.loop();             // check for shower on/off
@@ -1887,6 +1880,14 @@ void EMSESP::loop() {
         }
         scheduled_fetch_values(); // force a query on the EMS devices to fetch latest data at a set interval (1 min)
     }
+    // check for GPIO Errors - this is called once when booting
+    if (EMSESP::system_.systemStatus() == SYSTEM_STATUS::SYSTEM_STATUS_INVALID_GPIO) {
+        static bool only_once = false;
+        if (!only_once) {
+            LOG_ERROR("Invalid GPIOs used. Please check your settings and the system log");
+            only_once = true;
+        }
+    }
 
     if (EMSESP::system_.systemStatus() == SYSTEM_STATUS::SYSTEM_STATUS_PENDING_UPLOAD) {
         // start an upload from a URL, assuming the URL exists and set from a previous pass
@@ -1896,6 +1897,17 @@ void EMSESP::loop() {
             Shell::loop_all(); // flush log buffers so latest error message are shown in console
             system_.uploadFirmwareURL("reset");
             EMSESP::system_.systemStatus(SYSTEM_STATUS::SYSTEM_STATUS_ERROR_UPLOAD);
+        }
+    }
+
+    // reset status after 5 Minutes
+    if (EMSESP::system_.systemStatus() != SYSTEM_STATUS::SYSTEM_STATUS_NORMAL) {
+        static uint32_t starttime = 0;
+        if (starttime == 0) {
+            starttime = uuid::get_uptime_ms();
+        } else if (uuid::get_uptime_ms() - starttime > 300000) {
+            starttime = 0;
+            EMSESP::system_.systemStatus(SYSTEM_STATUS::SYSTEM_STATUS_NORMAL);
         }
     }
 

--- a/src/devices/thermostat.cpp
+++ b/src/devices/thermostat.cpp
@@ -4189,7 +4189,7 @@ bool Thermostat::set_temperature(const float temperature, const uint8_t mode, co
             if (model == EMSdevice::EMS_DEVICE_FLAG_CR120 && mode_ == HeatingCircuit::Mode::MANUAL) {
                 offset = 22; // manual offset CR120
             } else if (mode_ == HeatingCircuit::Mode::MANUAL) {
-                offset = 10; // manual offset
+                offset = hc->hpoperatingstate == 2 ? 17 : 10; // cooling or manual offset
             } else {
                 offset = 8; // auto offset
                 // special case to reactivate auto temperature, see #737, #746

--- a/src/web/WebStatusService.cpp
+++ b/src/web/WebStatusService.cpp
@@ -177,6 +177,10 @@ void WebStatusService::systemStatus(AsyncWebServerRequest * request) {
         // we're ready to do the actual restart ASAP
         EMSESP::system_.systemStatus(SYSTEM_STATUS::SYSTEM_STATUS_RESTART_REQUESTED);
     }
+    if (EMSESP::system_.systemStatus() == SYSTEM_STATUS::SYSTEM_STATUS_ERROR_UPLOAD) {
+        // error is reported, back to normal state
+        EMSESP::system_.systemStatus(SYSTEM_STATUS::SYSTEM_STATUS_NORMAL);
+    }
 
 #endif
 


### PR DESCRIPTION
this resets the status after 5 minutes, or via status page.
Also include the old fix for #1781

I've reverted all tests for #3107, seems that i'll never get a feedback to these tests and will never get a log of changing the modes. So the cooling modes stay unclear and better to leave it on the working heating modes.