### PR TITLE
Fix: AP crash and infinite loop during WiFi scan.

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -12,5 +12,6 @@ For more details go to [emsesp.org](https://emsesp.org/).
 
 - signed value for solarInfuence [#3077](https://github.com/emsesp/EMS-ESP32/issues/3077)
 - set bin file upload limit to 1M again [3086](https://github.com/emsesp/EMS-ESP32/issues/3086)
+- Fix: Prevent system crash during WiFi network discovery on ESP32-S3 hardware [#3128](https://github.com/emsesp/EMS-ESP32/pull/3128)
 
 ## Changed

--- a/src/ESP32React/WiFiScanner.cpp
+++ b/src/ESP32React/WiFiScanner.cpp
@@ -15,7 +15,7 @@ void WiFiScanner::scanNetworks(AsyncWebServerRequest * request) {
 
     if (WiFi.scanComplete() != -1) {
         WiFi.scanDelete();
-        WiFi.scanNetworks(true);
+        WiFi.scanNetworks(true, false, true, 250);
     }
 }
 
@@ -38,6 +38,10 @@ void WiFiScanner::listNetworks(AsyncWebServerRequest * request) {
     } else if (numNetworks == -1) {
         request->send(202); // special code to indicate scan in progress
     } else {
-        scanNetworks(request);
+        auto * response = new AsyncJsonResponse(false);
+        JsonObject root = response->getRoot();
+        root["networks"].to<JsonArray>();
+        response->setLength();
+        request->send(response);
     }
 }

--- a/src/emsesp_version.h
+++ b/src/emsesp_version.h
@@ -1,1 +1,1 @@
-#define EMSESP_APP_VERSION "3.8.3-dev.5"
+#define EMSESP_APP_VERSION "3.8.3-dev.6"


### PR DESCRIPTION
This PR addresses stability issues during WiFi network scans, specifically Access Point (AP) dropouts.

Before making these software changes, I verified the hardware using an oscilloscope to rule out voltage drops or brownouts during the scan. The issues are entirely software-related and stem from two separate logic flaws in src/ESP32React/WiFiScanner.cpp.

Fix 1: Preventing AP Dropouts (Passive Scan)

    Problem: The original WiFi.scanNetworks(true) call uses default Arduino core parameters. This results in an active scan that blocks the single radio for too long, causing devices connected to the AP to time out and drop the connection.

    Solution: Changed the call to WiFi.scanNetworks(true, false, true, 250);. Switching to a passive scan with a 250ms dwell time per channel gives the AP enough airtime to maintain active connections while still reliably finding all available SSIDs.

Fix 2: Breaking the Infinite Crash-Loop

    Problem: In listNetworks(), if the internal WiFi driver aborts a scan (e.g., due to heavy AP traffic), WiFi.scanComplete() returns -2 (WIFI_SCAN_FAILED). This previously fell into the final else block, which blindly triggered scanNetworks(request);. Combined with the React frontend's constant polling, this forced the ESP32 into a rapid, endless loop of restarting the scan driver, ultimately crashing the AP.

    Solution: Replaced the scan trigger in the else block with an empty JSON array response. This cleanly signals the frontend that the scan has finished (albeit without results), successfully stopping the frontend polling loop and allowing the system to recover gracefully.

Best regards,
soderdaen with massive AI help