### PR TITLE
fix: negative dew point calculation (emulated RC100H)

### DIFF
--- a/src/core/roomcontrol.cpp
+++ b/src/core/roomcontrol.cpp
@@ -377,19 +377,23 @@ void Roomctrl::temperature(uint8_t addr, uint8_t dst, uint8_t hc) {
 
 // send telegram 0x047B only for RC100H
 void Roomctrl::humidity(uint8_t addr, uint8_t dst, uint8_t hc) {
+    int16_t dew  = calc_dew(remotetemp_[hc], remotehum_[hc]);
+    int8_t  dew8 = EMS_VALUE_INT8_NOTSET;
+    if (dew != EMS_VALUE_INT16_NOTSET) {
+        dew8 = static_cast<int8_t>((dew >= 0 ? dew + 5 : dew - 5) / 10);
+    }
     uint8_t data[11];
-    data[0]      = addr | EMSbus::ems_mask();
-    data[1]      = dst & 0x7F;
-    uint16_t dew = calc_dew(remotetemp_[hc], remotehum_[hc]);
-    data[2]      = 0xFF;
-    data[3]      = 0;
-    data[4]      = 3;
-    data[5]      = 0x7B + hc;
-    data[6]      = dew == EMS_VALUE_INT16_NOTSET ? EMS_VALUE_INT8_NOTSET : (uint8_t)((dew + 5) / 10);
-    data[7]      = remotehum_[hc];
-    data[8]      = (uint8_t)(dew << 8);
-    data[9]      = (uint8_t)(dew & 0xFF);
-    data[10]     = EMSbus::calculate_crc(data, 10); // append CRC
+    data[0]  = addr | EMSbus::ems_mask();
+    data[1]  = dst & 0x7F;
+    data[2]  = 0xFF;
+    data[3]  = 0;
+    data[4]  = 3;
+    data[5]  = 0x7B + hc;
+    data[6]  = static_cast<uint8_t>(dew8);
+    data[7]  = remotehum_[hc];
+    data[8]  = static_cast<uint8_t>(static_cast<uint16_t>(dew) >> 8);
+    data[9]  = static_cast<uint8_t>(static_cast<uint16_t>(dew) & 0xFF);
+    data[10] = EMSbus::calculate_crc(data, 10); // append CRC
     EMSuart::transmit(data, 11);
 }
 


### PR DESCRIPTION
### Summary
If the dew point of an emulated RC100H would be negative, an integer overflow results in a wrong value reported to the heat pump.

### Steps to reproduce:
1. Go to "Devices" and select the BC400-HP 
2. Send values for `hc1 room temperature from remote` and `hc1 room humidity from remote` 
3. Go to "Devices" and select RC100H. Check whether "hc1 dew point temperature" is correct.

Example with correct dew point (greater than 0 °C): 
<img width="530" height="295" alt="dew_point_ok" src="https://github.com/user-attachments/assets/c136987a-7813-40f9-ab1b-8d4af108c891" />

Example with wrong dew point (slightly below 0 °C):
<img width="530" height="338" alt="dew_point_faulty" src="https://github.com/user-attachments/assets/1c6de227-f599-421a-bb2f-5c2c4c7b8fd1" />

### Impact
If the dew point goes below 0 °C, a high dew point is sent to the HP, which (typically) will let the HP detect a temperature below the dew point and immediately stops cooling.