### PR TITLE
update water.cpp: modify set_wwCircTc to use new command values

### DIFF
--- a/src/devices/water.cpp
+++ b/src/devices/water.cpp
@@ -361,7 +361,7 @@ bool Water::set_wwCircTc(const char * value, const int8_t id) {
     if (!Helpers::value2bool(value, b)) {
         return false;
     }
-    write_command(0x33B + dhw_, 4, b ? 0x01 : 0x00, 0x33B + dhw_);
+    write_command(0x7A5, 4, b ? 0xFF : 0x00, 0x7A5);
     return true;
 }
 


### PR DESCRIPTION
This pull request makes a targeted change to the `Water::set_wwCircTc` method, updating the way commands are written when setting a value.

Device command update:

* Changed the `write_command` call in `Water::set_wwCircTc` to use a fixed address (`0x7A5`) and updated the command value to `0xFF` when enabled (previously used a variable address and `0x01`).

Behavior in my system using the SM100 with a Buderus FS20 was wrong and didn't worked. 
With the changed implementation controlling Timed based circulation On/Off worked fine.