### PR TITLE
api attributs

### DIFF
--- a/src/web/WebCommandService.cpp
+++ b/src/web/WebCommandService.cpp
@@ -318,10 +318,19 @@ bool WebCommandService::get_value_info(JsonObject output, const char * cmd) {
         return true;
     }
 
-    if (!strlen(cmd) || !strcmp(cmd, F_(values)) || !strcmp(cmd, F_(info))) {
+    if (!strlen(cmd) || !strcmp(cmd, F_(values))) {
         for (const CommandItem & ci : *commandItems_) {
             if (ci.name[0] != '\0') {
-                output[(const char *)ci.name] = ci.cmd;
+                output[(const char *)ci.name] = ci.value.c_str();
+            }
+        }
+        return true;
+    }
+
+    if (!strcmp(cmd, F_(info))) {
+        for (const CommandItem & ci : *commandItems_) {
+            if (ci.name[0] != '\0') {
+                output[(const char *)ci.name] = std::string(ci.cmd + ": " + ci.value);
             }
         }
         return true;
@@ -364,7 +373,7 @@ std::string WebCommandService::get_metrics_prometheus() {
         if (ci.name[0] == '\0') {
             continue;
         }
-        result += (std::string) "# HELP emsesp_cmd_" + ci.name + " " + ci.name + "\n";
+        result += (std::string) "# HELP emsesp_cmd_" + ci.name + " " + ci.name + ", readabe, writable, visible\n";
         result += (std::string) "# TYPE emsesp_cmd_" + ci.name + " gauge\n";
         result += (std::string) "emsesp_cmd_" + ci.name + " 1\n";
     }
@@ -394,7 +403,7 @@ void WebCommandService::publish(const bool force) {
     JsonObject   output = doc.to<JsonObject>();
     for (const CommandItem & ci : *commandItems_) {
         if (ci.name[0] != '\0' && !output[ci.name].is<JsonVariantConst>()) {
-            output[(const char *)ci.name] = ci.cmd;
+            output[(const char *)ci.name] = ci.value.c_str();
         }
     }
 

--- a/src/web/WebSchedulerService.cpp
+++ b/src/web/WebSchedulerService.cpp
@@ -203,7 +203,7 @@ void WebSchedulerService::get_value_json(JsonObject output, const ScheduleItem &
     output["name"]     = (const char *)scheduleItem.name;
     output["fullname"] = (const char *)scheduleItem.name;
     output["type"]     = "boolean";
-    Mqtt::add_value_bool(output, "active", scheduleItem.active);
+    Mqtt::add_value_bool(output, "value", scheduleItem.active);
     if (scheduleItem.flags == SCHEDULEFLAG_SCHEDULE_CONDITION) {
         output["condition"] = scheduleItem.time;
     } else if (scheduleItem.flags == SCHEDULEFLAG_SCHEDULE_ONCHANGE) {


### PR DESCRIPTION
Now all readable entities have a `value` field and `api/device/values`  shows this field, also `api/device/shortname/value` gives this value back.
For api/commands/info` it shows name: a string that contains `"command:value"`
Scheduler in core2 have command/value fiellds and the setable was called `active`. Now this is in line and `value` is the on/off stable/readable state.

I think now fits all in one scheme.

One thing left: Because the commands execute on call the command.cpp checks the attribute first and execute if not found. 
so for an unknow attribute it give authentification failed instead of attribute not found back. Not critical but confusion. Maybe we need an extra check for the attribute separator.