### PR TITLE
Fix SM200/SM100 used as plain DHW station getting wrong telegram flag (fixes #3164)

### DIFF
--- a/src/core/emsesp.cpp
+++ b/src/core/emsesp.cpp
@@ -1378,6 +1378,12 @@ bool EMSESP::add_device(const uint8_t device_id, const uint8_t product_id, const
     }
     if ((device_id >= EMSdevice::EMS_DEVICE_ID_DHW1 && device_id <= EMSdevice::EMS_DEVICE_ID_DHW8) || device_id == EMSdevice::EMS_DEVICE_ID_IPM_DHW) {
         device_type = DeviceType::WATER;
+        // SM100/SM200 (product 163/164) used as a plain DHW/"Warmwassersystem" charging station
+        // (no solar collector) speak the MMPLUS telegram family (0x331/0x313/...), not the SM100
+        // solar telegrams (0x7A6/0x7D4/0x7DE) that the SOLAR-type table entry's flag would imply.
+        if (product_id == 163 || product_id == 164) {
+            flags = DeviceFlags::EMS_DEVICE_FLAG_MMPLUS;
+        }
     }
 
     // set MH210 with id 0x20 as mixer, see https://github.com/emsesp/EMS-ESP32/discussions/2138

--- a/test/test_api/test_api.cpp
+++ b/test/test_api/test_api.cpp
@@ -162,6 +162,19 @@ void add_devices() {
     uart_telegram({0x90, 0x00, 0xFF, 0x00, 0x00, 0x70, 0x02, 0x01, 0x00, 0xCE, 0x00, 0xE5});
     uart_telegram({0x90, 0x00, 0xFF, 0x00, 0x00, 0x71, 0x01, 0x02, 0x00, 0xCF, 0x00, 0xE6});
 
+    //
+    // water (SM200/MS200 used as a plain DHW "Warmwassersystem" charging station, not solar -
+    // see https://github.com/emsesp/EMS-ESP32/issues/3164 and PR #3165). Registered at device_id
+    // 0x28 (EMS_DEVICE_ID_DHW1), product 164, which must be re-flagged EMS_DEVICE_FLAG_MMPLUS so
+    // it listens for the MMPLUS telegrams (0x331/0x313) this unit actually sends, instead of the
+    // SM100 solar telegrams (0x7A6/0x7D4/0x7DE) it would otherwise wait for forever.
+    //
+    add_device(0x28, 164); // SM200/MS200
+
+    // Water(0x28) -> all, MMPLUSStatusMessage_WWC(0x331), captured on real hardware
+    // (BBQKees E32V2.2 gateway, SM200 firmware 25.06): dhw temp 55.6°C, pump off
+    uart_telegram({0x28, 0x00, 0xFF, 0x00, 0x02, 0x31, 0x02, 0x2C, 0x00, 0x37, 0x01, 0x37, 0x3C, 0x46, 0x02, 0x03, 0x05, 0x00, 0x00});
+
     // send the telegrams
     EMSESP::rxservice_.loop();
 }
@@ -379,6 +392,15 @@ void manual_test10() {
     }
 }
 
+// Regression test for https://github.com/emsesp/EMS-ESP32/issues/3164 (PR #3165):
+// SM200/MS200 (product 164) used as a plain DHW/"Warmwassersystem" station (no solar) must be
+// device-typed WATER *and* flagged MMPLUS so it processes the 0x331 telegram it actually sends.
+// Before the fix this device stayed on EMS_DEVICE_FLAG_SM100 and never received any data.
+void manual_test11() {
+    auto expected_response = "[{\"api_data\":\"55.6\"}]";
+    TEST_ASSERT_EQUAL_STRING(expected_response, call_url("/api/water/dhw.temp/value"));
+}
+
 void run_manual_tests() {
     RUN_TEST(manual_test1);
     RUN_TEST(manual_test2);
@@ -390,6 +412,7 @@ void run_manual_tests() {
     RUN_TEST(manual_test8);
     RUN_TEST(manual_test9);
     RUN_TEST(manual_test10);
+    RUN_TEST(manual_test11);
 }
 
 const char * run_console_command(const char * command) {

--- a/test/test_api/test_api.h
+++ b/test/test_api/test_api.h
@@ -227,7 +227,7 @@ void test_23() {
         "\"publish2command\":false,\"sendResponse\":false},\"syslog\":{\"enabled\":false},\"modbus\":{\"enabled\":false},\"sensor\":{\"temperatureSensors\":3,"
         "\"temperatureSensorReads\":0,\"temperatureSensorFails\":0},\"analog\":{\"enabled\":true,\"analogSensors\":5,\"analogSensorReads\":0,"
         "\"analogSensorFails\":0},\"api\":{\"APICalls\":0,\"APIFails\":0},\"bus\":{\"busStatus\":\"connected\",\"busProtocol\":\"Buderus\","
-        "\"busTelegramsReceived\":8,\"busReads\":0,\"busWrites\":0,\"busIncompleteTelegrams\":0,\"busReadsFailed\":0,\"busWritesFailed\":0,"
+        "\"busTelegramsReceived\":10,\"busReads\":0,\"busWrites\":0,\"busIncompleteTelegrams\":0,\"busReadsFailed\":0,\"busWritesFailed\":0,"
         "\"busRxLineQuality\":100,\"busTxLineQuality\":100},\"settings\":{\"boardProfile\":\"S32\",\"locale\":\"en\",\"txMode\":5,\"emsBusID\":73,"
         "\"showerTimer\":false,\"showerMinDuration\":180,\"showerAlert\":false,\"hideLed\":false,\"noTokenApi\":false,\"readonlyMode\":false,\"fahrenheit\":"
         "false,\"dallasParasite\":false,\"boolFormat\":1,\"boolDashboard\":1,\"enumFormat\":1,\"analogEnabled\":true,\"telnetEnabled\":true,"
@@ -238,8 +238,10 @@ void test_23() {
         "0x2E "
         "0x3B\"},{\"type\":\"thermostat\",\"name\":\"FW120\",\"deviceID\":\"0x10\",\"productID\":192,\"brand\":\"\",\"version\":\"01.00\",\"entities\":12,"
         "\"handlersReceived\":\"0x016F\",\"handlersFetched\":\"0x0170 0x0171\",\"handlersPending\":\"0xA3 0x06 0xA2 0x12 0x13 0x0172 0x0165 "
-        "0x0168\"},{\"type\":\"temperaturesensor\",\"name\":\"temperaturesensor\",\"entities\":3},{\"type\":\"analogsensor\",\"name\":\"analogsensor\","
-        "\"entities\":5},{\"type\":\"scheduler\",\"name\":\"scheduler\",\"entities\":2},{\"type\":\"custom\",\"name\":\"custom\",\"entities\":4}]}]";
+        "0x0168\"},{\"type\":\"water\",\"name\":\"SM200, "
+        "MS200\",\"deviceID\":\"0x28\",\"productID\":164,\"brand\":\"\",\"version\":\"01.00\",\"entities\":3,\"handlersReceived\":\"0x0331\"},{\"type\":"
+        "\"temperaturesensor\",\"name\":\"temperaturesensor\",\"entities\":3},{\"type\":\"analogsensor\",\"name\":\"analogsensor\",\"entities\":5},{\"type\":"
+        "\"scheduler\",\"name\":\"scheduler\",\"entities\":2},{\"type\":\"custom\",\"name\":\"custom\",\"entities\":4}]}]";
     TEST_ASSERT_EQUAL_STRING(expected_response, call_url("/api/system"));
 }
 
@@ -258,7 +260,7 @@ void test_24() {
         "\"publish2command\":false,\"sendResponse\":false},\"syslog\":{\"enabled\":false},\"modbus\":{\"enabled\":false},\"sensor\":{\"temperatureSensors\":3,"
         "\"temperatureSensorReads\":0,\"temperatureSensorFails\":0},\"analog\":{\"enabled\":true,\"analogSensors\":5,\"analogSensorReads\":0,"
         "\"analogSensorFails\":0},\"api\":{\"APICalls\":0,\"APIFails\":0},\"bus\":{\"busStatus\":\"connected\",\"busProtocol\":\"Buderus\","
-        "\"busTelegramsReceived\":8,\"busReads\":0,\"busWrites\":0,\"busIncompleteTelegrams\":0,\"busReadsFailed\":0,\"busWritesFailed\":0,"
+        "\"busTelegramsReceived\":10,\"busReads\":0,\"busWrites\":0,\"busIncompleteTelegrams\":0,\"busReadsFailed\":0,\"busWritesFailed\":0,"
         "\"busRxLineQuality\":100,\"busTxLineQuality\":100},\"settings\":{\"boardProfile\":\"S32\",\"locale\":\"en\",\"txMode\":5,\"emsBusID\":73,"
         "\"showerTimer\":false,\"showerMinDuration\":180,\"showerAlert\":false,\"hideLed\":false,\"noTokenApi\":false,\"readonlyMode\":false,\"fahrenheit\":"
         "false,\"dallasParasite\":false,\"boolFormat\":1,\"boolDashboard\":1,\"enumFormat\":1,\"analogEnabled\":true,\"telnetEnabled\":true,"
@@ -269,8 +271,10 @@ void test_24() {
         "0x2E "
         "0x3B\"},{\"type\":\"thermostat\",\"name\":\"FW120\",\"deviceID\":\"0x10\",\"productID\":192,\"brand\":\"\",\"version\":\"01.00\",\"entities\":12,"
         "\"handlersReceived\":\"0x016F\",\"handlersFetched\":\"0x0170 0x0171\",\"handlersPending\":\"0xA3 0x06 0xA2 0x12 0x13 0x0172 0x0165 "
-        "0x0168\"},{\"type\":\"temperaturesensor\",\"name\":\"temperaturesensor\",\"entities\":3},{\"type\":\"analogsensor\",\"name\":\"analogsensor\","
-        "\"entities\":5},{\"type\":\"scheduler\",\"name\":\"scheduler\",\"entities\":2},{\"type\":\"custom\",\"name\":\"custom\",\"entities\":4}]}]";
+        "0x0168\"},{\"type\":\"water\",\"name\":\"SM200, "
+        "MS200\",\"deviceID\":\"0x28\",\"productID\":164,\"brand\":\"\",\"version\":\"01.00\",\"entities\":3,\"handlersReceived\":\"0x0331\"},{\"type\":"
+        "\"temperaturesensor\",\"name\":\"temperaturesensor\",\"entities\":3},{\"type\":\"analogsensor\",\"name\":\"analogsensor\",\"entities\":5},{\"type\":"
+        "\"scheduler\",\"name\":\"scheduler\",\"entities\":2},{\"type\":\"custom\",\"name\":\"custom\",\"entities\":4}]}]";
     TEST_ASSERT_EQUAL_STRING(expected_response, call_url("/api/system/info"));
 }
 
@@ -322,7 +326,7 @@ void test_25() {
         "emsesp_analog_analogsensorreads gauge\\nemsesp_analog_analogsensorreads 0\\n# HELP emsesp_analog_analogsensorfails analogSensorFails\\n# TYPE "
         "emsesp_analog_analogsensorfails gauge\\nemsesp_analog_analogsensorfails 0\\n# HELP emsesp_api_apicalls APICalls\\n# TYPE emsesp_api_apicalls "
         "gauge\\nemsesp_api_apicalls 0\\n# HELP emsesp_api_apifails APIFails\\n# TYPE emsesp_api_apifails gauge\\nemsesp_api_apifails 0\\n# HELP "
-        "emsesp_bus_bustelegramsreceived busTelegramsReceived\\n# TYPE emsesp_bus_bustelegramsreceived gauge\\nemsesp_bus_bustelegramsreceived 8\\n# HELP "
+        "emsesp_bus_bustelegramsreceived busTelegramsReceived\\n# TYPE emsesp_bus_bustelegramsreceived gauge\\nemsesp_bus_bustelegramsreceived 10\\n# HELP "
         "emsesp_bus_busreads busReads\\n# TYPE emsesp_bus_busreads gauge\\nemsesp_bus_busreads 0\\n# HELP emsesp_bus_buswrites busWrites\\n# TYPE "
         "emsesp_bus_buswrites gauge\\nemsesp_bus_buswrites 0\\n# HELP emsesp_bus_busincompletetelegrams busIncompleteTelegrams\\n# TYPE "
         "emsesp_bus_busincompletetelegrams gauge\\nemsesp_bus_busincompletetelegrams 0\\n# HELP emsesp_bus_busreadsfailed busReadsFailed\\n# TYPE "
@@ -355,7 +359,9 @@ void test_25() {
         "gauge\\nemsesp_device_entities{type=\\\"boiler\\\", name=\\\"My Custom Boiler\\\", deviceid=\\\"0x08\\\", version=\\\"01.00\\\"} "
         "39\\nemsesp_device_productid{type=\\\"thermostat\\\", name=\\\"FW120\\\", deviceid=\\\"0x10\\\", version=\\\"01.00\\\"} "
         "192\\nemsesp_device_entities{type=\\\"thermostat\\\", name=\\\"FW120\\\", deviceid=\\\"0x10\\\", version=\\\"01.00\\\"} "
-        "12\\nemsesp_device_entities{type=\\\"temperaturesensor\\\", name=\\\"temperaturesensor\\\"} 3\\nemsesp_device_entities{type=\\\"analogsensor\\\", "
+        "12\\nemsesp_device_productid{type=\\\"water\\\", name=\\\"SM200, MS200\\\", deviceid=\\\"0x28\\\", version=\\\"01.00\\\"} "
+        "164\\nemsesp_device_entities{type=\\\"water\\\", name=\\\"SM200, MS200\\\", deviceid=\\\"0x28\\\", version=\\\"01.00\\\"} "
+        "3\\nemsesp_device_entities{type=\\\"temperaturesensor\\\", name=\\\"temperaturesensor\\\"} 3\\nemsesp_device_entities{type=\\\"analogsensor\\\", "
         "name=\\\"analogsensor\\\"} 5\\nemsesp_device_entities{type=\\\"scheduler\\\", name=\\\"scheduler\\\"} 2\\nemsesp_device_entities{type=\\\"custom\\\", "
         "name=\\\"custom\\\"} 4\\n\"}]";
     TEST_ASSERT_EQUAL_STRING(expected_response, call_url("/api/system/metrics"));


### PR DESCRIPTION
## Summary
Fixes #3164.

SM200/MS200 (and SM100/MS100 — product IDs 163/164) configured for a plain DHW/"Warmwassersystem"
charging circuit (no solar collector) actually speak the **MMPLUS** telegram family on the bus
(`0x331`/`0x313`/...), not the **SM100 solar** telegrams (`0x7A6`/`0x7D4`/`0x7DE`) implied by the
`DeviceType::SOLAR` table entry's flag that gets carried over when the device is re-typed to
`DeviceType::WATER` (device_id in the `DHW1..DHW8` range).

This mirrors the existing MH210 precedent a few lines below in the same function (see
https://github.com/emsesp/EMS-ESP32/discussions/2138), which already re-sets `flags` when
re-typing a device based on `device_id`, not just `product_id`.

## Change
One block in `src/core/emsesp.cpp`, `EMSESP::add_device()`: when a 163/164-product device is
re-typed to `WATER`, also switch its `flags` to `EMS_DEVICE_FLAG_MMPLUS`.

## Test plan
- [x] Built from the `v3.8.2` tag + this change (PlatformIO `s_16M_P` env) and flashed to a real
      BBQKees E32V2.2 gateway via the normal web OTA upload.
- [x] Before: `show devices` showed the Water Module with telegrams `0x7A6`/`0x7D4`/`0x7DE`
      permanently `Pending`, zero received/fetched, no dhw values available via MQTT/HA.
- [x] After: `show devices` shows `Received: 0x331`, `Fetched: 0x313`, **no pending telegrams**.
      Live values now available (`dhw_temp: 55.5`, `dhw_maxtemp: 60`, `dhw_redtemp: 55`,
      `dhw_requiredtemp: 55`, `dhw_disinfectiontemp: 70`, `dhw_pump: off`) — matching the values
      configured in the RC310's own "Warmwassersystem I" config screen (Max. Warmwassertemp 60°C,
      Warmwasser 55°C).
- [ ] Not tested: genuine solar-collector + SM100 DHW3 installations. From reading the code, these
      use a different `device_id` (DHW3/DHW4 range with `flags == EMS_DEVICE_FLAG_SM100` extra
      registrations), so should be unaffected by this product-ID-scoped change — but I don't have
      that hardware to verify. Happy to adjust if a maintainer sees a conflict.
