### PR TITLE
port two espMqttClient fixes from upstream 1.7.3

### DIFF
--- a/lib/espMqttClient/src/MqttClient.cpp
+++ b/lib/espMqttClient/src/MqttClient.cpp
@@ -62,11 +62,16 @@ MqttClient::MqttClient(espMqttClientTypes::UseInternalTask useInternalTask, uint
   _xSemaphore = xSemaphoreCreateMutex();
   EMC_SEMAPHORE_GIVE();  // release before first use
   if (_useInternalTask == espMqttClientTypes::UseInternalTask::YES) {
+#ifdef CONFIG_FREERTOS_UNICORE
+    // no core to pin to on single-core targets (S2, C3, C6)
+    xTaskCreate((TaskFunction_t)_loop, "mqttclient", EMC_TASK_STACK_SIZE, this, priority, &_taskHandle);
+#else
     if (core > 1) {
       xTaskCreate((TaskFunction_t)_loop, "mqttclient", EMC_TASK_STACK_SIZE, this, priority, &_taskHandle);
     } else {
       xTaskCreatePinnedToCore((TaskFunction_t)_loop, "mqttclient", EMC_TASK_STACK_SIZE, this, priority, &_taskHandle, core);
     }
+#endif
   }
 #else
   (void) useInternalTask;

--- a/lib/espMqttClient/src/Outbox.h
+++ b/lib/espMqttClient/src/Outbox.h
@@ -154,8 +154,12 @@ class Outbox {
     if (!it) return;
     Node* node = it._node;
     Node* prev = it._prev;
-    ++it;
+    Node* next = node->next;
+
     _remove(prev, node);
+
+    it._prev = prev;
+    it._node = next;
   }
 
   // remove current node, current points to next


### PR DESCRIPTION
Two changes ported across from the latest official esoMqttClient library.

1) Outbox::remove() advanced the iterator before deleting the node, so it._prev was left pointing at freed memory. A second removal on the same iterator wrote through it, corrupting _first/_last. _clearQueue(0) runs on every TCP disconnect and removes in a loop, so at QoS >= 1 a disconnect with packets queued behind an unacked publish could trash the
heap.

2) MqttClient's constructor pinned the task to EMSESP_MQTT_RUNNING_CORE unconditionally, but that core doesn't exist on the single-core S2/C3/C6 targets. Skip pinning when CONFIG_FREERTOS_UNICORE is set.