### PR TITLE
workaround for memory leak, #3184

### DIFF
--- a/CHANGELOG_LATEST.md
+++ b/CHANGELOG_LATEST.md
@@ -16,6 +16,7 @@ This release is based on the latest Espressif/Arduino core version 3. It brings 
 ## Fixed
 
 - shunting yard show json
+- memory leak when using different timezones for ems-esp and thermostat[#3184](https://github.com/emsesp/EMS-ESP32/issues/3184)
 
 ## Changed
 

--- a/src/ESP32React/NTPSettingsService.cpp
+++ b/src/ESP32React/NTPSettingsService.cpp
@@ -77,13 +77,15 @@ void NTPSettings::read(NTPSettings & settings, JsonObject root) {
     root["enabled"]         = settings.enabled;
     root["server"]          = settings.server;
     root["tz_label"]        = settings.tzLabel;
-    root["tz_format"]       = settings.tzFormat;
+    root["tz_format"]       = settings.tzFormat.substring(0, settings.tzFormat.indexOf(" "));
     root["thermostat_sync"] = settings.thermostat_sync;
     root["tz_label_t"]      = settings.tzLabelT;
-    root["tz_format_t"]     = settings.tzFormatT;
+    root["tz_format_t"]     = settings.tzFormatT.substring(0, settings.tzFormatT.indexOf(" "));
 }
 
 StateUpdateResult NTPSettings::update(JsonObject root, NTPSettings & settings) {
+    settings.tzFormat.reserve(40);
+    settings.tzFormatT.reserve(40);
     settings.enabled         = root["enabled"] | FACTORY_NTP_ENABLED;
     settings.server          = root["server"] | FACTORY_NTP_SERVER;
     settings.tzLabel         = root["tz_label"] | FACTORY_NTP_TIME_ZONE_LABEL;
@@ -91,5 +93,12 @@ StateUpdateResult NTPSettings::update(JsonObject root, NTPSettings & settings) {
     settings.thermostat_sync = root["thermostat_sync"] | FACTORY_NTP_THERMOSTAT_SYNC;
     settings.tzLabelT        = root["tz_label_t"] | FACTORY_NTP_TIME_ZONE_LABEL;
     settings.tzFormatT       = root["tz_format_t"] | FACTORY_NTP_TIME_ZONE_FORMAT;
+    // The format string must have same length to avoid memory leak, #3184
+    while (settings.tzFormat.length() < 40) {
+        settings.tzFormat += " ";
+    }
+    while (settings.tzFormatT.length() < 40) {
+        settings.tzFormatT += " ";
+    }
     return StateUpdateResult::CHANGED;
 }

--- a/src/emsesp_version.h
+++ b/src/emsesp_version.h
@@ -1,1 +1,1 @@
-#define EMSESP_APP_VERSION "3.9.0-dev.1"
+#define EMSESP_APP_VERSION "3.9.0-dev.2"


### PR DESCRIPTION
confirmed working.
What about 3.8.4 main? Leave it? make 3.8.5? I have a 3.8.4-patch.1 as source in my main branch, but no binaries.