### PR TITLE
Add OLIMEXPOEW board profile; guard against PSRAM/Ethernet clock GPIO conflict

### DIFF
--- a/interface/src/app/main/types.ts
+++ b/interface/src/app/main/types.ts
@@ -307,6 +307,7 @@ export const BOARD_PROFILES = {
   LOLIN: 'Lolin D32',
   OLIMEX: 'Olimex ESP32-EVB',
   OLIMEXPOE: 'Olimex ESP32-POE',
+  OLIMEXPOEW: 'Olimex ESP32-POE-ISO WROVER (PSRAM)',
   C3MINI: 'Wemos C3 Mini',
   S2MINI: 'Wemos S2 Mini',
   S3MINI: 'Liligo S3'

--- a/src/core/console.cpp
+++ b/src/core/console.cpp
@@ -305,7 +305,7 @@ static void setup_commands(std::shared_ptr<Commands> const & commands) {
             std::string         board_profile = Helpers::toUpper(arguments.front());
             if (!EMSESP::system_.load_board_profile(data, board_profile)) {
                 shell.println(
-                    "Invalid board profile (S32, E32, E32V2, E32V2_2, MH-ET, NODEMCU, LOLIN, OLIMEX, OLIMEXPOE, C3MINI, S2MINI, S3MINI, S32S3, CUSTOM)");
+                    "Invalid board profile (S32, E32, E32V2, E32V2_2, MH-ET, NODEMCU, LOLIN, OLIMEX, OLIMEXPOE, OLIMEXPOEW, C3MINI, S2MINI, S3MINI, S32S3, CUSTOM)");
                 return;
             }
 

--- a/src/core/network.cpp
+++ b/src/core/network.cpp
@@ -229,7 +229,9 @@ void Network::reconnect() {
 // boards without an Ethernet PHY skip straight to WIFI; without a configured SSID, straight to AP
 // (unless AP provision mode is Never — then stay on WIFI and keep waiting)
 NetPhase Network::initialPhase() const {
-    if (phy_type_ != PHY_type::PHY_TYPE_NONE) {
+    bool eth_clock_conflicts_psram = ESP.getPsramSize()
+                                      && ((eth_clock_mode_t)eth_clock_mode_ == ETH_CLOCK_GPIO16_OUT || (eth_clock_mode_t)eth_clock_mode_ == ETH_CLOCK_GPIO17_OUT);
+    if (phy_type_ != PHY_type::PHY_TYPE_NONE && !eth_clock_conflicts_psram) {
         return NetPhase::ETHERNET;
     }
     if (!ssid_.isEmpty() || ap_provisionMode_ == AP_MODE_NEVER) {
@@ -597,6 +599,11 @@ void Network::startEthernet() {
 
     // no ethernet present
     if (phy_type_ == PHY_type::PHY_TYPE_NONE) {
+        return;
+    }
+
+    if (ESP.getPsramSize() && ((eth_clock_mode_t)eth_clock_mode_ == ETH_CLOCK_GPIO16_OUT || (eth_clock_mode_t)eth_clock_mode_ == ETH_CLOCK_GPIO17_OUT)) {
+        LOG_ERROR("Ethernet clock mode %d (GPIO16/17) conflicts with PSRAM - disabling Ethernet", eth_clock_mode_);
         return;
     }
 

--- a/src/core/system.cpp
+++ b/src/core/system.cpp
@@ -2822,6 +2822,9 @@ bool System::load_board_profile(std::vector<int8_t> & data, const std::string & 
         // https://github.com/OLIMEX/ESP32-POE/blob/master/HARDWARE/ESP32-PoE-hardware-revision-L1/ESP32-PoE_Rev_L1.pdf
         // uart0 = 1, 3; SD-card = 2, 14, 15; button = 34;
         valid_system_gpios_ = {4, 34, 36, 12, 13, 21, 22, 25, 26, 27, 32, 33, 39};
+    } else if (board_profile == "OLIMEXPOEW") {
+        data = {0, 0, 36, 4, 34, PHY_type::PHY_TYPE_LAN8720, 12, 0, 1, 0}; // Olimex ESP32-POE-ISO WROVER (PSRAM)
+        valid_system_gpios_ = {4, 34, 36, 12, 13, 21, 22, 25, 26, 27, 32, 33, 39};
     } else if (board_profile == "C3MINI") {
 #if defined(BOARD_C3_MINI_V1)
         data = {7, 1, 4, 5, 9, PHY_type::PHY_TYPE_NONE, 0, 0, 0, 0}; // Lolin C3 Mini V1


### PR DESCRIPTION
## Problem

On classic ESP32 (D0WD), external/off-package PSRAM (used by WROVER modules) is wired to GPIO16 (CS) and GPIO17 (CLK). These are the same two pins `ETH.begin()` can use to drive the RMII clock output (`ETH_CLOCK_GPIO16_OUT` / `ETH_CLOCK_GPIO17_OUT`). Calling `ETH.begin()` with one of those clock modes while PSRAM is enabled doesn't fail cleanly - it corrupts heap metadata and crash-loops the device (`Guru Meditation Error: StoreProhibited`) on every boot, before the console or network ever come up. Recovery requires a full flash erase.

This is exactly what happens with the existing `OLIMEXPOE` board profile (Olimex ESP32-POE, `eth_clock_mode=3`/`ETH_CLOCK_GPIO17_OUT`) on the WROVER/PSRAM variant of that board (e.g. ESP32-POE-ISO-WROVER). That clock mode is correct for the WROOM (no PSRAM) variant, but crashes the WROVER variant.

Confirmed directly with Olimex support ([forum thread](https://www.olimex.com/forum/index.php?topic=9374.0)):

> When WROVER module (instead of the default WROOM) is used then GPIO16 and GPIO17 are unavailable (both are used for the PSRAM inside the module).
>
> For boards using WROVER, the Ethernet clock moved from GPIO17 to GPIO0

Also matches known arduino-esp32 issues: espressif/arduino-esp32#3979, espressif/arduino-esp32#6417.

## Fix

1. **New `OLIMEXPOEW` board profile** - same GPIOs as `OLIMEXPOE` but `eth_clock_mode=1` (`ETH_CLOCK_GPIO0_OUT`), matching Olimex's own pin change for the WROVER variant.
2. **Guard in `Network::initialPhase()` / `Network::startEthernet()`** - detects `PSRAM enabled && eth_clock_mode in {GPIO16_OUT, GPIO17_OUT}` and skips Ethernet (falls back to WiFi/AP) instead of calling `ETH.begin()` into the crash. This isn't just for the new profile - anyone who picks the existing, ambiguous `OLIMEXPOE` name on WROVER hardware, or configures `CUSTOM` with that combination, now gets a clean fallback instead of a crash-loop that requires a full flash erase to recover from.

## Testing

Both changes verified on real Olimex ESP32-POE-ISO-WROVER hardware (ESP32-D0WD-V3) over serial console, against both `3.8.4` (release) and current `dev` (3.9.0-dev, Arduino Core 3.3.8 / IDF 5.5.4):

- `OLIMEXPOE` (the conflicting combination) previously crash-looped every boot (`Guru Meditation Error: StoreProhibited`, `EXCVADDR: 0x0000000b`, traced to `heap_tlsf.c` via `uart_driver_install` <- `System::uart_init`). With this fix it boots clean, logs the new error, and comes up in AP mode. PSRAM confirmed still available.
- `OLIMEXPOEW` boots clean with PSRAM available, and the Ethernet PHY link actually comes up - confirmed via a directly connected host's NIC reporting `100baseTX <full-duplex>` link state.
